### PR TITLE
feat: add theme class helper

### DIFF
--- a/app/(features)/home/components/HomeSearch.tsx
+++ b/app/(features)/home/components/HomeSearch.tsx
@@ -1,6 +1,7 @@
 'use client';
 import { SearchSolidIcon } from '@/app/shared/icons';
 import { useTheme } from '@/app/providers/ThemeContext';
+import { themeClass } from '@/lib/utils/themeClass';
 
 interface HomeSearchProps {
   searchQuery: string;
@@ -11,10 +12,11 @@ export default function HomeSearch({ searchQuery, setSearchQuery }: HomeSearchPr
   const { theme } = useTheme();
   const shortcutSurahs = ['Al-Mulk', 'Al-Kahf', 'Ya-Sin', 'Al-Ikhlas'];
 
-  const searchBarClasses =
-    theme === 'light'
-      ? 'bg-white text-gray-700 border-none placeholder-gray-400'
-      : 'bg-gray-800 text-gray-200 border-none placeholder-gray-400';
+  const searchBarClasses = themeClass(
+    theme,
+    'bg-white text-gray-700 border-none placeholder-gray-400',
+    'bg-gray-800 text-gray-200 border-none placeholder-gray-400'
+  );
 
   return (
     <>
@@ -29,7 +31,7 @@ export default function HomeSearch({ searchQuery, setSearchQuery }: HomeSearchPr
             placeholder="What do you want to read?"
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            className={`w-full pl-12 pr-4 py-3 rounded-lg ring-0 focus:outline-none focus:ring-0 transition-all duration-300 hover:shadow-lg text-lg ${searchBarClasses} backdrop-blur-xl shadow-lg hover:shadow-xl ${theme === 'light' ? 'bg-white/60' : 'bg-slate-800/50'} animate-fade-in-up animation-delay-200`}
+            className={`w-full pl-12 pr-4 py-3 rounded-lg ring-0 focus:outline-none focus:ring-0 transition-all duration-300 hover:shadow-lg text-lg ${searchBarClasses} backdrop-blur-xl shadow-lg hover:shadow-xl ${themeClass(theme, 'bg-white/60', 'bg-slate-800/50')} animate-fade-in-up animation-delay-200`}
           />
         </div>
       </div>
@@ -38,11 +40,11 @@ export default function HomeSearch({ searchQuery, setSearchQuery }: HomeSearchPr
         {shortcutSurahs.map((name) => (
           <button
             key={name}
-            className={`px-4 sm:px-5 py-2 rounded-full font-medium shadow-sm transition-all duration-200 ${
-              theme === 'light'
-                ? 'bg-white border border-gray-200 text-slate-800 hover:bg-gray-100 hover:shadow-md'
-                : 'bg-slate-800/40 border-slate-700/50 text-slate-300 backdrop-blur-md hover:bg-slate-700/60 hover:scale-105 transform hover:shadow-md'
-            }`}
+            className={`px-4 sm:px-5 py-2 rounded-full font-medium shadow-sm transition-all duration-200 ${themeClass(
+              theme,
+              'bg-white border border-gray-200 text-slate-800 hover:bg-gray-100 hover:shadow-md',
+              'bg-slate-800/40 border-slate-700/50 text-slate-300 backdrop-blur-md hover:bg-slate-700/60 hover:scale-105 transform hover:shadow-md'
+            )}`}
           >
             {name}
           </button>

--- a/app/(features)/home/components/HomeTabs.tsx
+++ b/app/(features)/home/components/HomeTabs.tsx
@@ -1,6 +1,7 @@
 'use client';
 import React, { useState } from 'react';
 import { useTheme } from '@/app/providers/ThemeContext';
+import { themeClass } from '@/lib/utils/themeClass';
 import SurahTab from './SurahTab';
 import JuzTab from './JuzTab';
 import PageTab from './PageTab';
@@ -18,18 +19,26 @@ export default function HomeTabs({ searchQuery }: HomeTabsProps) {
       <div className="flex justify-between items-center mb-8 content-visibility-auto animate-fade-in-up animation-delay-600">
         <h2 className="text-3xl font-bold text-slate-900 dark:text-white">All Surahs</h2>
         <div
-          className={`flex items-center p-1 sm:p-2 rounded-full ${theme === 'light' ? 'bg-gray-100' : 'bg-slate-800/60'}`}
+          className={`flex items-center p-1 sm:p-2 rounded-full ${themeClass(
+            theme,
+            'bg-gray-100',
+            'bg-slate-800/60'
+          )}`}
         >
           <button
             onClick={() => setActiveTab('Surah')}
             className={`px-4 sm:px-5 py-2 rounded-full text-sm font-semibold transition-colors ${
               activeTab === 'Surah'
-                ? theme === 'light'
-                  ? 'bg-white shadow text-slate-900'
-                  : 'bg-slate-700 text-white shadow'
-                : theme === 'light'
-                  ? 'text-slate-500 hover:text-slate-800'
-                  : 'text-slate-400 hover:text-white'
+                ? themeClass(
+                    theme,
+                    'bg-white shadow text-slate-900',
+                    'bg-slate-700 text-white shadow'
+                  )
+                : themeClass(
+                    theme,
+                    'text-slate-500 hover:text-slate-800',
+                    'text-slate-400 hover:text-white'
+                  )
             }`}
           >
             Surah
@@ -38,12 +47,16 @@ export default function HomeTabs({ searchQuery }: HomeTabsProps) {
             onClick={() => setActiveTab('Juz')}
             className={`px-4 sm:px-5 py-2 rounded-full text-sm font-semibold transition-colors ${
               activeTab === 'Juz'
-                ? theme === 'light'
-                  ? 'bg-white shadow text-slate-900'
-                  : 'bg-slate-700 text-white shadow'
-                : theme === 'light'
-                  ? 'text-slate-500 hover:text-slate-800'
-                  : 'text-slate-400 hover:text-white'
+                ? themeClass(
+                    theme,
+                    'bg-white shadow text-slate-900',
+                    'bg-slate-700 text-white shadow'
+                  )
+                : themeClass(
+                    theme,
+                    'text-slate-500 hover:text-slate-800',
+                    'text-slate-400 hover:text-white'
+                  )
             }`}
           >
             Juz
@@ -52,12 +65,16 @@ export default function HomeTabs({ searchQuery }: HomeTabsProps) {
             onClick={() => setActiveTab('Page')}
             className={`px-4 sm:px-5 py-2 rounded-full text-sm font-semibold transition-colors ${
               activeTab === 'Page'
-                ? theme === 'light'
-                  ? 'bg-white shadow text-slate-900'
-                  : 'bg-slate-700 text-white shadow'
-                : theme === 'light'
-                  ? 'text-slate-500 hover:text-slate-800'
-                  : 'text-slate-400 hover:text-white'
+                ? themeClass(
+                    theme,
+                    'bg-white shadow text-slate-900',
+                    'bg-slate-700 text-white shadow'
+                  )
+                : themeClass(
+                    theme,
+                    'text-slate-500 hover:text-slate-800',
+                    'text-slate-400 hover:text-white'
+                  )
             }`}
           >
             Page

--- a/app/(features)/home/components/JuzTab.tsx
+++ b/app/(features)/home/components/JuzTab.tsx
@@ -1,6 +1,7 @@
 'use client';
 import Link from 'next/link';
 import { useTheme } from '@/app/providers/ThemeContext';
+import { themeClass } from '@/lib/utils/themeClass';
 import juzData from '@/data/juz.json';
 
 interface JuzSummary {
@@ -20,26 +21,26 @@ export default function JuzTab() {
         <Link
           href={`/juz/${juz.number}`}
           key={juz.number}
-          className={`group p-4 sm:p-5 rounded-2xl backdrop-blur-xl shadow-lg hover:shadow-xl transition-all duration-300 content-visibility-auto animate-fade-in-up ${theme === 'light' ? 'bg-white/60' : 'bg-slate-800/40'}`}
+          className={`group p-4 sm:p-5 rounded-2xl backdrop-blur-xl shadow-lg hover:shadow-xl transition-all duration-300 content-visibility-auto animate-fade-in-up ${themeClass(theme, 'bg-white/60', 'bg-slate-800/40')}`}
         >
           <div className="flex items-center justify-between">
             <div className="flex items-center space-x-4">
               <div
-                className={`flex items-center justify-center w-12 h-12 rounded-xl font-bold text-lg transition-colors ${
-                  theme === 'light'
-                    ? 'bg-gray-100 text-emerald-600 group-hover:bg-emerald-50/50'
-                    : 'bg-slate-700/50 text-emerald-400 group-hover:bg-emerald-500/20'
-                }`}
+                className={`flex items-center justify-center w-12 h-12 rounded-xl font-bold text-lg transition-colors ${themeClass(
+                  theme,
+                  'bg-gray-100 text-emerald-600 group-hover:bg-emerald-50/50',
+                  'bg-slate-700/50 text-emerald-400 group-hover:bg-emerald-500/20'
+                )}`}
               >
                 {juz.number}
               </div>
               <div>
                 <h3
-                  className={`font-semibold text-lg ${theme === 'light' ? 'text-slate-900' : 'text-white'}`}
+                  className={`font-semibold text-lg ${themeClass(theme, 'text-slate-900', 'text-white')}`}
                 >
                   {juz.name}
                 </h3>
-                <p className={`text-sm ${theme === 'light' ? 'text-slate-600' : 'text-slate-400'}`}>
+                <p className={`text-sm ${themeClass(theme, 'text-slate-600', 'text-slate-400')}`}>
                   {juz.surahRange}
                 </p>
               </div>

--- a/app/(features)/home/components/SurahTab.tsx
+++ b/app/(features)/home/components/SurahTab.tsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { useTheme } from '@/app/providers/ThemeContext';
+import { themeClass } from '@/lib/utils/themeClass';
 import { getSurahList } from '@/lib/api';
 import type { Surah } from '@/types';
 import Spinner from '@/app/shared/Spinner';
@@ -51,41 +52,41 @@ export default function SurahTab({ searchQuery }: SurahTabProps) {
         <Link
           href={`/surah/${surah.number}`}
           key={surah.number}
-          className={`group p-4 sm:p-5 rounded-2xl backdrop-blur-xl shadow-lg hover:shadow-xl transition-all duration-300 content-visibility-auto animate-fade-in-up ${theme === 'light' ? 'bg-white/60' : 'bg-slate-800/40'}`}
+          className={`group p-4 sm:p-5 rounded-2xl backdrop-blur-xl shadow-lg hover:shadow-xl transition-all duration-300 content-visibility-auto animate-fade-in-up ${themeClass(theme, 'bg-white/60', 'bg-slate-800/40')}`}
         >
           <div className="flex items-center justify-between">
             <div className="flex items-center space-x-4">
               <div
-                className={`flex items-center justify-center w-12 h-12 rounded-xl font-bold text-lg transition-colors ${
-                  theme === 'light'
-                    ? 'bg-gray-100 text-emerald-600 group-hover:bg-emerald-100'
-                    : 'bg-slate-700/50 text-emerald-400 group-hover:bg-emerald-500/20'
-                }`}
+                className={`flex items-center justify-center w-12 h-12 rounded-xl font-bold text-lg transition-colors ${themeClass(
+                  theme,
+                  'bg-gray-100 text-emerald-600 group-hover:bg-emerald-100',
+                  'bg-slate-700/50 text-emerald-400 group-hover:bg-emerald-500/20'
+                )}`}
               >
                 {surah.number}
               </div>
               <div>
                 <h3
-                  className={`font-semibold text-lg ${theme === 'light' ? 'text-slate-900' : 'text-white'}`}
+                  className={`font-semibold text-lg ${themeClass(theme, 'text-slate-900', 'text-white')}`}
                 >
                   {surah.name}
                 </h3>
-                <p className={`text-sm ${theme === 'light' ? 'text-slate-600' : 'text-slate-400'}`}>
+                <p className={`text-sm ${themeClass(theme, 'text-slate-600', 'text-slate-400')}`}>
                   {surah.meaning}
                 </p>
               </div>
             </div>
             <div className="text-right">
               <p
-                className={`font-amiri text-2xl ${
-                  theme === 'light'
-                    ? 'text-slate-800 group-hover:text-emerald-600'
-                    : 'text-slate-300 group-hover:text-emerald-400'
-                } transition-colors`}
+                className={`font-amiri text-2xl ${themeClass(
+                  theme,
+                  'text-slate-800 group-hover:text-emerald-600',
+                  'text-slate-300 group-hover:text-emerald-400'
+                )} transition-colors`}
               >
                 {surah.arabicName}
               </p>
-              <p className={`text-sm ${theme === 'light' ? 'text-slate-600' : 'text-slate-400'}`}>
+              <p className={`text-sm ${themeClass(theme, 'text-slate-600', 'text-slate-400')}`}>
                 {surah.verses} Verses
               </p>
             </div>

--- a/app/shared/surah-sidebar/Juz.tsx
+++ b/app/shared/surah-sidebar/Juz.tsx
@@ -1,6 +1,8 @@
 import Link from 'next/link';
 import type { Chapter } from '@/types';
 import { getSurahByPage, JUZ_START_PAGES } from '@/lib/utils/surah-navigation';
+import type { Theme } from '@/app/providers/ThemeContext';
+import { themeClass } from '@/lib/utils/themeClass';
 
 interface JuzSummary {
   number: number;
@@ -11,7 +13,7 @@ interface JuzSummary {
 interface Props {
   juzs: JuzSummary[];
   chapters: Chapter[];
-  theme: string;
+  theme: Theme;
   selectedJuzId: string | null;
   setSelectedJuzId: (id: string) => void;
   setSelectedPageId: (id: string) => void;
@@ -49,20 +51,22 @@ const Juz = ({
             className={`group flex items-center p-4 gap-4 rounded-xl transition transform hover:scale-[1.02] ${
               isActive
                 ? 'bg-teal-600 text-white shadow-lg shadow-teal-600/30'
-                : theme === 'light'
-                  ? 'bg-white shadow hover:bg-slate-50'
-                  : 'bg-slate-800 shadow hover:bg-slate-700'
+                : themeClass(
+                    theme,
+                    'bg-white shadow hover:bg-slate-50',
+                    'bg-slate-800 shadow hover:bg-slate-700'
+                  )
             }`}
           >
             <div
               className={`w-12 h-12 flex items-center justify-center rounded-xl font-bold text-lg shadow transition-colors ${
                 isActive
-                  ? theme === 'light'
-                    ? 'bg-gray-100 text-teal-600'
-                    : 'bg-slate-700 text-teal-400'
-                  : theme === 'light'
-                    ? 'bg-gray-100 text-teal-600 group-hover:bg-teal-100'
-                    : 'bg-slate-700 text-teal-400 group-hover:bg-teal-600/20'
+                  ? themeClass(theme, 'bg-gray-100 text-teal-600', 'bg-slate-700 text-teal-400')
+                  : themeClass(
+                      theme,
+                      'bg-gray-100 text-teal-600 group-hover:bg-teal-100',
+                      'bg-slate-700 text-teal-400 group-hover:bg-teal-600/20'
+                    )
               }`}
             >
               {juz.number}
@@ -72,20 +76,14 @@ const Juz = ({
                 className={`font-semibold ${
                   isActive
                     ? 'text-white'
-                    : theme === 'light'
-                      ? 'text-slate-700'
-                      : 'text-[var(--foreground)]'
+                    : themeClass(theme, 'text-slate-700', 'text-[var(--foreground)]')
                 }`}
               >
                 Juz {juz.number}
               </p>
               <p
                 className={`text-xs ${
-                  isActive
-                    ? 'text-white/90'
-                    : theme === 'light'
-                      ? 'text-slate-600'
-                      : 'text-slate-400'
+                  isActive ? 'text-white/90' : themeClass(theme, 'text-slate-600', 'text-slate-400')
                 }`}
               >
                 {juz.surahRange}

--- a/app/shared/surah-sidebar/Page.tsx
+++ b/app/shared/surah-sidebar/Page.tsx
@@ -1,11 +1,13 @@
 import Link from 'next/link';
 import type { Chapter } from '@/types';
 import { getJuzByPage, getSurahByPage } from '@/lib/utils/surah-navigation';
+import type { Theme } from '@/app/providers/ThemeContext';
+import { themeClass } from '@/lib/utils/themeClass';
 
 interface Props {
   pages: number[];
   chapters: Chapter[];
-  theme: string;
+  theme: Theme;
   selectedPageId: string | null;
   setSelectedPageId: (id: string) => void;
   setSelectedJuzId: (id: string) => void;
@@ -42,20 +44,22 @@ const Page = ({
             className={`group flex items-center p-4 gap-4 rounded-xl transition transform hover:scale-[1.02] ${
               isActive
                 ? 'bg-teal-600 text-white shadow-lg shadow-teal-600/30'
-                : theme === 'light'
-                  ? 'bg-white shadow hover:bg-slate-50'
-                  : 'bg-slate-800 shadow hover:bg-slate-700'
+                : themeClass(
+                    theme,
+                    'bg-white shadow hover:bg-slate-50',
+                    'bg-slate-800 shadow hover:bg-slate-700'
+                  )
             }`}
           >
             <div
               className={`w-12 h-12 flex items-center justify-center rounded-xl font-bold text-lg shadow transition-colors ${
                 isActive
-                  ? theme === 'light'
-                    ? 'bg-gray-100 text-teal-600'
-                    : 'bg-slate-700 text-teal-400'
-                  : theme === 'light'
-                    ? 'bg-gray-100 text-teal-600 group-hover:bg-teal-100'
-                    : 'bg-slate-700 text-teal-400 group-hover:bg-teal-600/20'
+                  ? themeClass(theme, 'bg-gray-100 text-teal-600', 'bg-slate-700 text-teal-400')
+                  : themeClass(
+                      theme,
+                      'bg-gray-100 text-teal-600 group-hover:bg-teal-100',
+                      'bg-slate-700 text-teal-400 group-hover:bg-teal-600/20'
+                    )
               }`}
             >
               {p}
@@ -64,9 +68,7 @@ const Page = ({
               className={`font-semibold ${
                 isActive
                   ? 'text-white'
-                  : theme === 'light'
-                    ? 'text-slate-700'
-                    : 'text-[var(--foreground)]'
+                  : themeClass(theme, 'text-slate-700', 'text-[var(--foreground)]')
               }`}
             >
               Page {p}

--- a/app/shared/surah-sidebar/Surah.tsx
+++ b/app/shared/surah-sidebar/Surah.tsx
@@ -1,10 +1,12 @@
 import Link from 'next/link';
 import type { Chapter } from '@/types';
 import { getJuzByPage } from '@/lib/utils/surah-navigation';
+import type { Theme } from '@/app/providers/ThemeContext';
+import { themeClass } from '@/lib/utils/themeClass';
 
 interface Props {
   chapters: Chapter[];
-  theme: string;
+  theme: Theme;
   selectedSurahId: string | null;
   setSelectedSurahId: (id: string) => void;
   setSelectedPageId: (id: string) => void;
@@ -42,20 +44,22 @@ const Surah = ({
             className={`group flex items-center p-4 gap-4 rounded-xl transition transform hover:scale-[1.02] ${
               isActive
                 ? 'bg-teal-600 text-white shadow-lg shadow-teal-600/30'
-                : theme === 'light'
-                  ? 'bg-white shadow hover:bg-slate-50'
-                  : 'bg-slate-800 shadow hover:bg-slate-700'
+                : themeClass(
+                    theme,
+                    'bg-white shadow hover:bg-slate-50',
+                    'bg-slate-800 shadow hover:bg-slate-700'
+                  )
             }`}
           >
             <div
               className={`w-12 h-12 flex items-center justify-center rounded-xl font-bold text-lg shadow transition-colors ${
                 isActive
-                  ? theme === 'light'
-                    ? 'bg-gray-100 text-teal-600'
-                    : 'bg-slate-700 text-teal-400'
-                  : theme === 'light'
-                    ? 'bg-gray-100 text-teal-600 group-hover:bg-teal-100'
-                    : 'bg-slate-700 text-teal-400 group-hover:bg-teal-600/20'
+                  ? themeClass(theme, 'bg-gray-100 text-teal-600', 'bg-slate-700 text-teal-400')
+                  : themeClass(
+                      theme,
+                      'bg-gray-100 text-teal-600 group-hover:bg-teal-100',
+                      'bg-slate-700 text-teal-400 group-hover:bg-teal-600/20'
+                    )
               }`}
             >
               {chapter.id}
@@ -65,9 +69,7 @@ const Surah = ({
                 className={`font-bold ${
                   isActive
                     ? 'text-white'
-                    : theme === 'light'
-                      ? 'text-slate-700'
-                      : 'text-[var(--foreground)]'
+                    : themeClass(theme, 'text-slate-700', 'text-[var(--foreground)]')
                 }`}
               >
                 {chapter.name_simple}
@@ -80,9 +82,11 @@ const Surah = ({
               className={`font-amiri text-xl font-bold transition-colors ${
                 isActive
                   ? 'text-white'
-                  : theme === 'light'
-                    ? 'text-gray-500 group-hover:text-teal-600'
-                    : 'text-gray-500 group-hover:text-teal-400'
+                  : themeClass(
+                      theme,
+                      'text-gray-500 group-hover:text-teal-600',
+                      'text-gray-500 group-hover:text-teal-400'
+                    )
               }`}
             >
               {chapter.name_arabic}

--- a/app/shared/surah-sidebar/components/SidebarTabs.tsx
+++ b/app/shared/surah-sidebar/components/SidebarTabs.tsx
@@ -5,19 +5,24 @@ interface Tab {
   label: string;
 }
 
+import type { Theme } from '@/app/providers/ThemeContext';
+import { themeClass } from '@/lib/utils/themeClass';
+
 interface Props {
   tabs: Tab[];
   activeTab: 'Surah' | 'Juz' | 'Page';
   setActiveTab: (tab: 'Surah' | 'Juz' | 'Page') => void;
   prepareForTabSwitch: (tab: 'Surah' | 'Juz' | 'Page') => void;
-  theme: string;
+  theme: Theme;
 }
 
 const SidebarTabs = ({ tabs, activeTab, setActiveTab, prepareForTabSwitch, theme }: Props) => (
   <div
-    className={`flex items-center p-1 rounded-full ${
-      theme === 'light' ? 'bg-gray-100' : 'bg-slate-800/60'
-    }`}
+    className={`flex items-center p-1 rounded-full ${themeClass(
+      theme,
+      'bg-gray-100',
+      'bg-slate-800/60'
+    )}`}
   >
     {tabs.map(({ key, label }) => (
       <button
@@ -28,12 +33,12 @@ const SidebarTabs = ({ tabs, activeTab, setActiveTab, prepareForTabSwitch, theme
         }}
         className={`w-1/3 px-4 py-2 text-sm font-semibold rounded-full transition-colors ${
           activeTab === key
-            ? theme === 'light'
-              ? 'bg-white text-slate-900 shadow'
-              : 'bg-slate-700 text-white shadow'
-            : theme === 'light'
-              ? 'text-slate-400 hover:text-slate-700'
-              : 'text-slate-400 hover:text-white'
+            ? themeClass(theme, 'bg-white text-slate-900 shadow', 'bg-slate-700 text-white shadow')
+            : themeClass(
+                theme,
+                'text-slate-400 hover:text-slate-700',
+                'text-slate-400 hover:text-white'
+              )
         }`}
       >
         {label}

--- a/lib/utils/__tests__/themeClass.test.ts
+++ b/lib/utils/__tests__/themeClass.test.ts
@@ -1,0 +1,11 @@
+import { themeClass } from '../themeClass';
+
+describe('themeClass', () => {
+  it('returns light classes for light theme', () => {
+    expect(themeClass('light', 'light-class', 'dark-class')).toBe('light-class');
+  });
+
+  it('returns dark classes for dark theme', () => {
+    expect(themeClass('dark', 'light-class', 'dark-class')).toBe('dark-class');
+  });
+});

--- a/lib/utils/themeClass.ts
+++ b/lib/utils/themeClass.ts
@@ -1,0 +1,6 @@
+import type { Theme } from '@/app/providers/ThemeContext';
+
+export const themeClass = (theme: Theme, light: string, dark: string): string =>
+  theme === 'light' ? light : dark;
+
+export default themeClass;


### PR DESCRIPTION
## Summary
- add themeClass utility for theme-based styles
- refactor home tabs, search, and sidebar components to use themeClass
- cover themeClass with unit tests

## Testing
- `npm run format`
- `npm run lint` *(fails: The autoFocus prop should not be used)*
- `npm run check` *(fails: The autoFocus prop should not be used)*
- `npm test` *(fails: TestingLibraryElementError: Unable to find an element with the text: Al-Fatihah)*

------
https://chatgpt.com/codex/tasks/task_b_68a1c349b7a4832fb62c9a3722e9fd8d