### PR TITLE
feat: add ThemedCard component for home tabs

### DIFF
--- a/app/(features)/home/components/JuzTab.tsx
+++ b/app/(features)/home/components/JuzTab.tsx
@@ -1,7 +1,7 @@
 'use client';
-import Link from 'next/link';
 import { useTheme } from '@/app/providers/ThemeContext';
 import juzData from '@/data/juz.json';
+import ThemedCard from './ThemedCard';
 
 interface JuzSummary {
   number: number;
@@ -17,11 +17,7 @@ export default function JuzTab() {
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
       {allJuz.map((juz) => (
-        <Link
-          href={`/juz/${juz.number}`}
-          key={juz.number}
-          className={`group p-4 sm:p-5 rounded-2xl backdrop-blur-xl shadow-lg hover:shadow-xl transition-all duration-300 content-visibility-auto animate-fade-in-up ${theme === 'light' ? 'bg-white/60' : 'bg-slate-800/40'}`}
-        >
+        <ThemedCard href={`/juz/${juz.number}`} key={juz.number}>
           <div className="flex items-center justify-between">
             <div className="flex items-center space-x-4">
               <div
@@ -45,7 +41,7 @@ export default function JuzTab() {
               </div>
             </div>
           </div>
-        </Link>
+        </ThemedCard>
       ))}
     </div>
   );

--- a/app/(features)/home/components/PageTab.tsx
+++ b/app/(features)/home/components/PageTab.tsx
@@ -1,6 +1,6 @@
 'use client';
-import Link from 'next/link';
 import { useTheme } from '@/app/providers/ThemeContext';
+import ThemedCard from './ThemedCard';
 
 const allPages = Array.from({ length: 604 }, (_, i) => i + 1);
 
@@ -10,11 +10,7 @@ export default function PageTab() {
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
       {allPages.map((page) => (
-        <Link
-          href={`/page/${page}`}
-          key={page}
-          className={`group p-4 sm:p-5 rounded-2xl backdrop-blur-xl shadow-lg hover:shadow-xl transition-all duration-300 content-visibility-auto animate-fade-in-up ${theme === 'light' ? 'bg-white/60' : 'bg-slate-800/40'}`}
-        >
+        <ThemedCard href={`/page/${page}`} key={page}>
           <div className="flex items-center space-x-4">
             <div
               className={`flex items-center justify-center w-12 h-12 rounded-xl font-bold text-lg transition-colors ${
@@ -31,7 +27,7 @@ export default function PageTab() {
               Page {page}
             </h3>
           </div>
-        </Link>
+        </ThemedCard>
       ))}
     </div>
   );

--- a/app/(features)/home/components/SurahTab.tsx
+++ b/app/(features)/home/components/SurahTab.tsx
@@ -1,10 +1,10 @@
 'use client';
 import React, { useEffect, useMemo, useState } from 'react';
-import Link from 'next/link';
 import { useTheme } from '@/app/providers/ThemeContext';
 import { getSurahList } from '@/lib/api';
 import type { Surah } from '@/types';
 import Spinner from '@/app/shared/Spinner';
+import ThemedCard from './ThemedCard';
 
 interface SurahTabProps {
   searchQuery: string;
@@ -48,11 +48,7 @@ export default function SurahTab({ searchQuery }: SurahTabProps) {
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
       {filteredSurahs.map((surah) => (
-        <Link
-          href={`/surah/${surah.number}`}
-          key={surah.number}
-          className={`group p-4 sm:p-5 rounded-2xl backdrop-blur-xl shadow-lg hover:shadow-xl transition-all duration-300 content-visibility-auto animate-fade-in-up ${theme === 'light' ? 'bg-white/60' : 'bg-slate-800/40'}`}
-        >
+        <ThemedCard href={`/surah/${surah.number}`} key={surah.number}>
           <div className="flex items-center justify-between">
             <div className="flex items-center space-x-4">
               <div
@@ -90,7 +86,7 @@ export default function SurahTab({ searchQuery }: SurahTabProps) {
               </p>
             </div>
           </div>
-        </Link>
+        </ThemedCard>
       ))}
     </div>
   );

--- a/app/(features)/home/components/ThemedCard.tsx
+++ b/app/(features)/home/components/ThemedCard.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import Link from 'next/link';
+import { useTheme } from '@/app/providers/ThemeContext';
+import type { ReactNode } from 'react';
+
+interface ThemedCardProps {
+  href: string;
+  children: ReactNode;
+  className?: string;
+}
+
+export default function ThemedCard({ href, children, className = '' }: ThemedCardProps) {
+  const { theme } = useTheme();
+
+  return (
+    <Link
+      href={href}
+      className={`group p-4 sm:p-5 rounded-2xl backdrop-blur-xl shadow-lg hover:shadow-xl transition-all duration-300 content-visibility-auto animate-fade-in-up ${theme === 'light' ? 'bg-white/60' : 'bg-slate-800/40'} ${className}`}
+    >
+      {children}
+    </Link>
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable ThemedCard with theme-aware styling
- refactor home tabs to use ThemedCard wrapper

## Testing
- `npm run format`
- `npm run lint` *(fails: The autoFocus prop should not be used, as it can reduce usability and accessibility for users.)*
- `npm run check` *(fails: The autoFocus prop should not be used, as it can reduce usability and accessibility for users.)*
- `npm run type-check` *(fails: Property 'bookmarkedVerses' does not exist on type 'BookmarkContextType'.)*
- `npm test -- app/\(features\)/home`

------
https://chatgpt.com/codex/tasks/task_b_68a1c3536a88832f957deb7bdb20a514