### PR TITLE
feat: centralize theme variables

### DIFF
--- a/app/(features)/home/__tests__/HomePage.test.tsx
+++ b/app/(features)/home/__tests__/HomePage.test.tsx
@@ -62,7 +62,7 @@ const renderHome = () => renderWithProviders(<HomePage />);
 
 beforeEach(() => {
   localStorage.clear();
-  document.documentElement.dataset.theme = '';
+  document.documentElement.classList.remove('dark');
 });
 
 it('search filtering returns only matching Surahs', async () => {
@@ -74,14 +74,14 @@ it('search filtering returns only matching Surahs', async () => {
   expect(screen.queryByText('Al-Fatihah')).not.toBeInTheDocument();
 });
 
-it('theme toggle updates the data-theme attribute', async () => {
+it('theme toggle updates the dark class', async () => {
   renderHome();
   const nav = screen.getByRole('navigation');
   const themeButton = within(nav).getByRole('button');
-  expect(document.documentElement.dataset.theme).toBe('light');
+  expect(document.documentElement.classList.contains('dark')).toBe(false);
   await userEvent.click(themeButton);
   await waitFor(() => {
-    expect(document.documentElement.dataset.theme).toBe('dark');
+    expect(document.documentElement.classList.contains('dark')).toBe(true);
   });
 });
 

--- a/app/(features)/home/__tests__/VerseOfDay.test.tsx
+++ b/app/(features)/home/__tests__/VerseOfDay.test.tsx
@@ -40,7 +40,7 @@ beforeAll(() => {
 beforeEach(() => {
   jest.useFakeTimers();
   localStorage.clear();
-  document.documentElement.dataset.theme = '';
+  document.documentElement.classList.remove('dark');
   mockedGetRandomVerse.mockReset();
 });
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,21 +1,6 @@
 /* ===== Tailwind Import (Required for Tailwind classes) ===== */
 @import 'tailwindcss';
-
-:root {
-  --background: #ffffff;
-  --foreground: #374151;
-  --border-color: #e5e7eb;
-  --accent: #0d9488;
-  --subtle-grey: #d1d5db;
-}
-
-[data-theme='dark'] {
-  --background: #1a202c;
-  --foreground: #d1d5db;
-  --border-color: #4b5563;
-  --accent: #0d9488;
-  --subtle-grey: #4b5563;
-}
+@import './theme.css';
 
 @layer base {
   body {
@@ -233,12 +218,12 @@ input[type='range']::-webkit-slider-thumb:hover {
 }
 
 /* Dark theme adjustments */
-[data-theme='dark'] .tafsir-content [lang='ar'] {
+.dark .tafsir-content [lang='ar'] {
   background: rgba(13, 148, 136, 0.15);
   border-color: rgba(13, 148, 136, 0.3);
 }
 
-[data-theme='dark'] .tafsir-content p:first-child::first-letter {
+.dark .tafsir-content p:first-child::first-letter {
   color: rgba(13, 148, 136, 0.9);
 }
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -80,7 +80,7 @@ export default async function RootLayout({ children }: { children: React.ReactNo
       : 'light';
 
   return (
-    <html lang="en" data-theme={theme} className={theme === 'dark' ? 'dark' : undefined}>
+    <html lang="en" className={theme === 'dark' ? 'dark' : undefined}>
       <body
         className={`font-sans ${kfgqpc.variable} ${nastaliq.variable} ${amiri.variable} ${arabic.variable} ${bengali.variable} ${crimsonText.variable} ${libreBaskerville.variable} ${inter.className}`}
       >

--- a/app/providers/ThemeContext.tsx
+++ b/app/providers/ThemeContext.tsx
@@ -37,11 +37,10 @@ export const ThemeProvider = ({
     }
   }, []); // Empty dependency array ensures this effect runs only once on mount
 
-  // Effect to save theme to localStorage and update data attribute whenever theme changes
+  // Effect to save theme to localStorage and toggle the dark class whenever theme changes
   useEffect(() => {
     if (typeof window !== 'undefined') {
       localStorage.setItem('theme', theme);
-      document.documentElement.dataset.theme = theme;
       // Ensure the dark class is toggled for Tailwind's class strategy
       document.documentElement.classList.toggle('dark', theme === 'dark');
       document.cookie = `theme=${theme}; path=/; max-age=31536000`;

--- a/app/providers/__tests__/ThemeContext.test.tsx
+++ b/app/providers/__tests__/ThemeContext.test.tsx
@@ -31,7 +31,7 @@ describe('ThemeContext', () => {
 
   beforeEach(() => {
     localStorage.clear();
-    document.documentElement.dataset.theme = '';
+    document.documentElement.classList.remove('dark');
   });
 
   it('useTheme throws when rendered without ThemeProvider', () => {
@@ -47,7 +47,7 @@ describe('ThemeContext', () => {
 
     await waitFor(() => {
       expect(screen.getByTestId('theme').textContent).toBe('light');
-      expect(document.documentElement.dataset.theme).toBe('light');
+      expect(document.documentElement.classList.contains('dark')).toBe(false);
       expect(localStorage.getItem('theme')).toBe('light');
     });
 
@@ -55,7 +55,7 @@ describe('ThemeContext', () => {
 
     await waitFor(() => {
       expect(screen.getByTestId('theme').textContent).toBe('dark');
-      expect(document.documentElement.dataset.theme).toBe('dark');
+      expect(document.documentElement.classList.contains('dark')).toBe(true);
       expect(localStorage.getItem('theme')).toBe('dark');
     });
   });

--- a/app/theme.css
+++ b/app/theme.css
@@ -1,0 +1,28 @@
+:root {
+  --color-surface: 247 249 249;
+  --color-text: 55 65 81;
+  --color-accent: 13 148 136;
+  --color-accent-hover: 15 118 110;
+  --color-border: 229 231 235;
+
+  /* legacy variables */
+  --background: rgb(var(--color-surface));
+  --foreground: rgb(var(--color-text));
+  --border-color: rgb(var(--color-border));
+  --accent: rgb(var(--color-accent));
+  --subtle-grey: rgb(var(--color-border));
+}
+
+.dark {
+  --color-surface: 26 32 44;
+  --color-text: 209 213 219;
+  --color-accent: 13 148 136;
+  --color-accent-hover: 15 118 110;
+  --color-border: 75 85 99;
+
+  --background: rgb(var(--color-surface));
+  --foreground: rgb(var(--color-text));
+  --border-color: rgb(var(--color-border));
+  --accent: rgb(var(--color-accent));
+  --subtle-grey: rgb(var(--color-border));
+}

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -7,11 +7,11 @@ const config = {
   theme: {
     extend: {
       colors: {
-        background: 'var(--background)',
-        foreground: 'var(--foreground)',
-        border: 'var(--border-color)',
-        accent: designTokens.colors.accent,
-        'accent-hover': designTokens.colors.accentHover,
+        background: 'rgb(var(--color-surface) / <alpha-value>)',
+        foreground: 'rgb(var(--color-text) / <alpha-value>)',
+        border: 'rgb(var(--color-border) / <alpha-value>)',
+        accent: 'rgb(var(--color-accent) / <alpha-value>)',
+        'accent-hover': 'rgb(var(--color-accent-hover) / <alpha-value>)',
         brand: '#009688',
       },
       spacing: designTokens.spacing,


### PR DESCRIPTION
## Summary
- define shared light and dark color tokens in `app/theme.css`
- hook Tailwind colors and global styles into new CSS variables
- drop `data-theme` handling in favor of toggling the `.dark` class

## Testing
- `npm install`
- `npm run check` *(fails: jsx-a11y/anchor-is-valid, react/no-unescaped-entities, etc.)*
- `npm test` *(fails: renders list of tafsir links, renders list of surah links)*
- `npm run type-check` *(fails: cannot find module '../storage/localStorage.js', etc.)*

------
https://chatgpt.com/codex/tasks/task_b_68a25f922810832f964138d52a2e20df