### PR TITLE
feat: replace color literals with tokens

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,3 +27,10 @@ Security audits run in CI. Optionally run `npm audit --omit=dev` locally to chec
 - Follow the project's ESLint configuration. Run `npm run format` followed by `npm run lint` and fix warnings when possible.
 - Use two spaces for indentation.
 - Write clear, descriptive variable and function names.
+
+## Design Tokens & Utilities
+
+- Use semantic token classes instead of hardcoded colors. Prefer `text-primary`, `text-muted`, and `bg-surface` over `text-gray-*` or `bg-white`. These classes adapt to light and dark themes automatically.
+- Reusable layout helpers live in `app/globals.css` under `@layer components`:
+  - `.section` provides standard page padding.
+  - `.card` applies surface background, padding, rounded corners, and a shadow for basic card layouts.

--- a/app/(features)/bookmarks/[folderId]/page.tsx
+++ b/app/(features)/bookmarks/[folderId]/page.tsx
@@ -11,8 +11,8 @@ interface PageProps {
 export default function BookmarkFolderPage({ params }: PageProps) {
   const { folderId } = React.use(params);
   return (
-    <div className="flex flex-grow bg-white dark:bg-[var(--background)] text-[var(--foreground)] overflow-hidden">
-      <main className="flex-grow p-6 lg:p-10 overflow-y-auto homepage-scrollable-area">
+    <div className="flex flex-grow bg-surface text-primary overflow-hidden">
+      <main className="flex-grow section overflow-y-auto homepage-scrollable-area">
         <h1 className="text-2xl font-bold mb-6">{folderId.replace(/-/g, ' ')}</h1>
         <BookmarkedVersesList />
       </main>

--- a/app/(features)/bookmarks/components/BookmarkListView.tsx
+++ b/app/(features)/bookmarks/components/BookmarkListView.tsx
@@ -20,14 +20,12 @@ export const BookmarkListView = ({ folder, onBack }: BookmarkListViewProps) => {
       <div className="mb-6 flex items-center gap-4">
         <button
           onClick={onBack}
-          className="rounded-md p-1.5 text-gray-600 hover:bg-gray-200 dark:text-gray-400 dark:hover:bg-gray-700"
+          className="rounded-md p-1.5 text-muted hover:bg-gray-200  hover:bg-surface/50"
         >
           <ArrowLeftIcon size={20} />
         </button>
-        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">{folder.name}</h1>
-        <span className="text-sm text-gray-500">
-          {folder.bookmarks.length} bookmarks
-        </span>
+        <h1 className="text-2xl font-bold text-primary ">{folder.name}</h1>
+        <span className="text-sm text-muted">{folder.bookmarks.length} bookmarks</span>
       </div>
 
       <div>
@@ -39,20 +37,20 @@ export const BookmarkListView = ({ folder, onBack }: BookmarkListViewProps) => {
                 initial={{ opacity: 0, y: 20 }}
                 animate={{ opacity: 1, y: 0 }}
                 transition={{ delay: index * 0.05 }}
-                className="cursor-pointer rounded-lg border border-gray-200 bg-white p-4 hover:bg-slate-50 dark:border-gray-700 dark:bg-gray-800 dark:hover:bg-gray-700/50"
+                className="cursor-pointer rounded-lg border border-gray-200 bg-surface p-4 hover:bg-slate-50 dark:border-gray-700  hover:bg-surface/50"
               >
                 {/* For now, just display the verse ID. This will be replaced with actual verse content later. */}
                 <p className="font-mono text-sm text-teal-600 dark:text-teal-400">
                   Verse: {bookmark.verseId}
                 </p>
-                <p className="text-xs text-gray-400">
+                <p className="text-xs text-muted">
                   Bookmarked on: {new Date(bookmark.createdAt).toLocaleDateString()}
                 </p>
               </motion.li>
             ))}
           </ul>
         ) : (
-          <div className="mt-10 text-center text-gray-500">
+          <div className="mt-10 text-center text-muted">
             <p>This folder is empty.</p>
             <p>You can add verses to it from the main reader.</p>
           </div>

--- a/app/(features)/bookmarks/components/BookmarkSidebar.tsx
+++ b/app/(features)/bookmarks/components/BookmarkSidebar.tsx
@@ -20,7 +20,7 @@ const BookmarkSidebar = () => {
 
   return (
     <aside
-      className={`fixed md:static top-16 md:top-0 bottom-0 left-0 w-[20.7rem] bg-white dark:bg-[var(--background)] text-[var(--foreground)] flex flex-col shadow-lg z-40 md:z-10 md:h-full transform transition-transform duration-300 ${
+      className={`fixed md:static top-16 md:top-0 bottom-0 left-0 w-[20.7rem] bg-surface  text-primary flex flex-col shadow-lg z-40 md:z-10 md:h-full transform transition-transform duration-300 ${
         isSurahListOpen ? 'translate-x-0' : '-translate-x-full md:translate-x-0'
       }`}
     >
@@ -33,7 +33,7 @@ const BookmarkSidebar = () => {
               key={l.href}
               href={l.href}
               className={`block px-3 py-2 rounded-md text-sm transition-colors hover:bg-gray-100 dark:hover:bg-slate-800 ${
-                active ? 'bg-gray-100 dark:bg-slate-800 font-semibold' : ''
+                active ? 'bg-gray-100  font-semibold' : ''
               }`}
             >
               {l.label}

--- a/app/(features)/bookmarks/components/CleanBookmarkComponents.tsx
+++ b/app/(features)/bookmarks/components/CleanBookmarkComponents.tsx
@@ -59,9 +59,7 @@ export const CleanSectionHeader = ({
             )}
           </div>
           {subtitle && (
-            <p className="text-gray-600 dark:text-gray-300 font-medium text-lg leading-relaxed max-w-2xl">
-              {subtitle}
-            </p>
+            <p className="text-muted  font-medium text-lg leading-relaxed max-w-2xl">{subtitle}</p>
           )}
         </div>
 
@@ -112,22 +110,22 @@ export const CleanFolderCard = ({
       {/* Header */}
       <div className="flex items-start justify-between mb-4">
         <div className="flex items-center gap-3">
-          <div className="w-12 h-12 rounded-xl flex items-center justify-center bg-white dark:bg-teal-900/50 shadow-sm border border-gray-200 dark:border-teal-600">
+          <div className="w-12 h-12 rounded-xl flex items-center justify-center bg-surface dark:bg-teal-900/50 shadow-sm border border-gray-200 dark:border-teal-600">
             <FolderIcon size={24} className="text-teal-600 dark:text-teal-400" />
           </div>
           <div>
             <h3 className="bm-heading text-lg line-clamp-1">{name}</h3>
-            <p className="text-gray-500 dark:text-gray-400 text-sm">
+            <p className="text-muted  text-sm">
               {count} {count === 1 ? 'bookmark' : 'bookmarks'}
             </p>
           </div>
         </div>
 
         <button
-          className="opacity-0 group-hover:opacity-100 transition-opacity duration-200 rounded-full p-2 hover:bg-white/50 dark:hover:bg-gray-800/50"
+          className="opacity-0 group-hover:opacity-100 transition-opacity duration-200 rounded-full p-2 hover:bg-surface/50 hover:bg-surface/50"
           onClick={(e) => e.stopPropagation()}
         >
-          <EllipsisHIcon size={18} className="text-gray-500 dark:text-gray-300" />
+          <EllipsisHIcon size={18} className="text-muted " />
         </button>
       </div>
 
@@ -137,7 +135,7 @@ export const CleanFolderCard = ({
           {preview.slice(0, 2).map((text, index) => (
             <div
               key={index}
-              className="text-gray-500 dark:text-gray-400 text-sm line-clamp-1 px-2 py-1 bg-white/50 dark:bg-gray-800/50 rounded"
+              className="text-muted  text-sm line-clamp-1 px-2 py-1 bg-surface/50  rounded"
             >
               {text}
             </div>
@@ -207,7 +205,7 @@ export const CleanBookmarkListView = ({ folder, onBack }: CleanBookmarkListViewP
                   <div className="flex items-center gap-2">
                     <span className="bm-badge bm-badge-general">Verse {bookmark.verseId}</span>
                   </div>
-                  <span className="text-xs text-emerald-600 dark:text-emerald-400 bg-white/50 dark:bg-emerald-900/30 px-2 py-1 rounded">
+                  <span className="text-xs text-emerald-600 dark:text-emerald-400 bg-surface/50 dark:bg-emerald-900/30 px-2 py-1 rounded">
                     {new Date(bookmark.createdAt).toLocaleDateString()}
                   </span>
                 </div>
@@ -227,13 +225,13 @@ export const CleanBookmarkListView = ({ folder, onBack }: CleanBookmarkListViewP
           </motion.ul>
         ) : (
           <div className="bm-section text-center">
-            <div className="bm-card bg-gray-50 dark:bg-gray-800/50 border-dashed border-gray-300 dark:border-gray-600">
+            <div className="bm-card bg-gray-50  border-dashed border-gray-300 dark:border-gray-600">
               <div className="py-12">
-                <div className="w-16 h-16 mx-auto mb-4 rounded-full bg-gray-200 dark:bg-gray-700 flex items-center justify-center">
-                  <FolderIcon size={32} className="text-gray-500 dark:text-gray-300" />
+                <div className="w-16 h-16 mx-auto mb-4 rounded-full bg-gray-200  flex items-center justify-center">
+                  <FolderIcon size={32} className="text-muted " />
                 </div>
                 <h3 className="bm-heading text-lg mb-2">This folder is empty</h3>
-                <p className="text-gray-600 dark:text-gray-300">
+                <p className="text-muted ">
                   Start adding verses to this folder while reading. You can bookmark verses by
                   clicking the bookmark icon next to any verse.
                 </p>

--- a/app/(features)/bookmarks/components/CreateFolderModal.tsx
+++ b/app/(features)/bookmarks/components/CreateFolderModal.tsx
@@ -37,16 +37,14 @@ export const CreateFolderModal = ({ isOpen, onClose }: CreateFolderModalProps) =
             initial={{ scale: 0.9, y: 20 }}
             animate={{ scale: 1, y: 0 }}
             exit={{ scale: 0.9, y: 20 }}
-            className="relative w-full max-w-md rounded-lg bg-white p-6 shadow-xl dark:bg-gray-800"
+            className="relative w-full max-w-md rounded-lg bg-surface p-6 shadow-xl "
             onClick={(e) => e.stopPropagation()}
           >
             <div className="flex items-center justify-between">
-              <h2 className="text-lg font-semibold text-gray-900 dark:text-white">
-                Create New Folder
-              </h2>
+              <h2 className="text-lg font-semibold text-primary ">Create New Folder</h2>
               <button
                 onClick={onClose}
-                className="rounded-full p-1 text-gray-500 hover:bg-gray-200 dark:text-gray-400 dark:hover:bg-gray-700"
+                className="rounded-full p-1 text-muted hover:bg-gray-200  hover:bg-surface/50"
               >
                 <CloseIcon size={20} />
               </button>
@@ -58,8 +56,7 @@ export const CreateFolderModal = ({ isOpen, onClose }: CreateFolderModalProps) =
                 value={folderName}
                 onChange={(e) => setFolderName(e.target.value)}
                 placeholder="Enter folder name"
-                className="w-full rounded-md border-gray-300 bg-gray-100 px-4 py-2 text-sm focus:border-teal-500 focus:ring-teal-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
-                autoFocus
+                className="w-full rounded-md border-gray-300 bg-gray-100 px-4 py-2 text-sm focus:border-teal-500 focus:ring-teal-500 dark:border-gray-600  "
               />
               <div className="mt-4 flex justify-end">
                 <button

--- a/app/(features)/bookmarks/components/EmptyStates.tsx
+++ b/app/(features)/bookmarks/components/EmptyStates.tsx
@@ -62,7 +62,7 @@ const EmptyStateBase = ({
       transition={{ delay: 0.3, duration: 0.5 }}
       className="max-w-md"
     >
-      <h3 className="text-xl font-semibold text-[var(--foreground)] mb-3">{title}</h3>
+      <h3 className="text-xl font-semibold text-primary mb-3">{title}</h3>
       <p className="text-muted leading-relaxed mb-6">{description}</p>
     </motion.div>
 
@@ -138,7 +138,7 @@ export const EmptyFolderState = () => (
           transition={{ delay: 0.2, type: 'spring', stiffness: 200 }}
           className="w-24 h-24 rounded-xl bg-gradient-to-br from-gray-100 to-gray-200 dark:from-gray-800 dark:to-gray-700 flex items-center justify-center border-2 border-dashed border-gray-300 dark:border-gray-600"
         >
-          <BookmarkIcon size={32} className="text-gray-400 dark:text-gray-500" />
+          <BookmarkIcon size={32} className="text-muted " />
         </motion.div>
         {/* Plus indicator */}
         <motion.div

--- a/app/(features)/bookmarks/components/EnhancedVisuals.tsx
+++ b/app/(features)/bookmarks/components/EnhancedVisuals.tsx
@@ -118,24 +118,24 @@ export const EnhancedFolderCard = ({
       {/* Header */}
       <div className="flex items-start justify-between mb-4">
         <div className="flex items-center gap-3">
-          <div className="w-12 h-12 rounded-xl flex items-center justify-center bg-white dark:bg-gray-800 shadow-sm border border-gray-200 dark:border-gray-700">
+          <div className="w-12 h-12 rounded-xl flex items-center justify-center bg-surface  shadow-sm border border-gray-200 dark:border-gray-700">
             <FolderIcon size={24} className="text-teal-600 dark:text-teal-400" />
           </div>
           <div>
             <h3 className={utils.cn(componentClasses.text.heading, 'text-lg line-clamp-1')}>
               {name}
             </h3>
-            <p className="text-sm text-gray-500 dark:text-gray-400">
+            <p className="text-sm text-muted ">
               {count} {count === 1 ? 'bookmark' : 'bookmarks'}
             </p>
           </div>
         </div>
 
         <button
-          className="opacity-0 group-hover:opacity-100 transition-opacity duration-200 rounded-full p-2 hover:bg-white/50 dark:hover:bg-gray-800/50"
+          className="opacity-0 group-hover:opacity-100 transition-opacity duration-200 rounded-full p-2 hover:bg-surface/50 hover:bg-surface/50"
           onClick={(e) => e.stopPropagation()}
         >
-          <EllipsisHIcon size={18} className="text-gray-500 dark:text-gray-400" />
+          <EllipsisHIcon size={18} className="text-muted " />
         </button>
       </div>
 
@@ -147,7 +147,7 @@ export const EnhancedFolderCard = ({
               key={index}
               className={utils.cn(
                 componentClasses.text.caption,
-                'line-clamp-1 px-2 py-1 bg-white/50 dark:bg-gray-800/50 rounded'
+                'line-clamp-1 px-2 py-1 bg-surface/50  rounded'
               )}
             >
               {text}
@@ -158,7 +158,7 @@ export const EnhancedFolderCard = ({
 
       {/* Footer */}
       {lastModified && (
-        <div className="flex items-center justify-between text-xs text-gray-500 dark:text-gray-400">
+        <div className="flex items-center justify-between text-xs text-muted ">
           <span>Updated {lastModified}</span>
           <motion.div
             initial={{ x: 0 }}
@@ -201,14 +201,12 @@ export const SidebarNavItem = ({
       <div
         className={utils.cn(
           'w-10 h-10 rounded-lg flex items-center justify-center transition-colors',
-          isActive ? 'bg-white dark:bg-gray-800 shadow-sm' : 'bg-gray-100 dark:bg-gray-700'
+          isActive ? 'bg-surface  shadow-sm' : 'bg-gray-100 '
         )}
       >
         <Icon
           size={20}
-          className={
-            isActive ? utils.getColorScheme(colorScheme).icon : 'text-gray-500 dark:text-gray-400'
-          }
+          className={isActive ? utils.getColorScheme(colorScheme).icon : 'text-muted '}
         />
       </div>
 
@@ -227,8 +225,8 @@ export const SidebarNavItem = ({
               className={utils.cn(
                 'text-xs px-2 py-1 rounded-full',
                 isActive
-                  ? utils.cn(utils.getColorScheme(colorScheme).text, 'bg-white dark:bg-gray-800')
-                  : 'text-gray-500 dark:text-gray-400 bg-gray-100 dark:bg-gray-700'
+                  ? utils.cn(utils.getColorScheme(colorScheme).text, 'bg-surface ')
+                  : 'text-muted  bg-gray-100 '
               )}
             >
               {count}

--- a/app/(features)/bookmarks/components/SimpleFolderCard.tsx
+++ b/app/(features)/bookmarks/components/SimpleFolderCard.tsx
@@ -32,24 +32,22 @@ export const SimpleFolderCard = ({
       {/* Header */}
       <div className="flex items-start justify-between mb-4">
         <div className="flex items-center gap-3">
-          <div className="w-12 h-12 rounded-xl flex items-center justify-center bg-white dark:bg-teal-900/50 shadow-sm border border-gray-200 dark:border-teal-600">
+          <div className="w-12 h-12 rounded-xl flex items-center justify-center bg-surface dark:bg-teal-900/50 shadow-sm border border-gray-200 dark:border-teal-600">
             <FolderIcon size={24} className="text-teal-600 dark:text-teal-400" />
           </div>
           <div>
-            <h3 className="text-lg font-semibold text-gray-900 dark:text-white line-clamp-1">
-              {name}
-            </h3>
-            <p className="text-sm text-gray-600 dark:text-gray-300">
+            <h3 className="text-lg font-semibold text-primary  line-clamp-1">{name}</h3>
+            <p className="text-sm text-muted ">
               {count} {count === 1 ? 'bookmark' : 'bookmarks'}
             </p>
           </div>
         </div>
 
         <button
-          className="opacity-0 group-hover:opacity-100 transition-opacity duration-200 rounded-full p-2 hover:bg-white/50 dark:hover:bg-gray-800/50"
+          className="opacity-0 group-hover:opacity-100 transition-opacity duration-200 rounded-full p-2 hover:bg-surface/50 hover:bg-surface/50"
           onClick={(e) => e.stopPropagation()}
         >
-          <EllipsisHIcon size={18} className="text-gray-500 dark:text-gray-400" />
+          <EllipsisHIcon size={18} className="text-muted " />
         </button>
       </div>
 
@@ -59,7 +57,7 @@ export const SimpleFolderCard = ({
           {preview.slice(0, 2).map((text, index) => (
             <div
               key={index}
-              className="text-xs text-gray-600 dark:text-gray-300 line-clamp-1 px-2 py-1 bg-white/50 dark:bg-gray-800/50 rounded"
+              className="text-xs text-muted  line-clamp-1 px-2 py-1 bg-surface/50  rounded"
             >
               {text}
             </div>
@@ -69,7 +67,7 @@ export const SimpleFolderCard = ({
 
       {/* Footer */}
       {lastModified && (
-        <div className="flex items-center justify-between text-xs text-gray-500 dark:text-gray-400">
+        <div className="flex items-center justify-between text-xs text-muted ">
           <span>Updated {lastModified}</span>
           <motion.div
             initial={{ x: 0 }}

--- a/app/(features)/bookmarks/components/SimpleSectionHeader.tsx
+++ b/app/(features)/bookmarks/components/SimpleSectionHeader.tsx
@@ -49,9 +49,7 @@ export const SimpleSectionHeader = ({
       <div className="flex flex-col sm:flex-row sm:items-end sm:justify-between gap-4">
         <div className="space-y-2">
           <div className="flex items-center gap-3">
-            <h1 className="text-3xl font-bold text-gray-900 dark:text-white tracking-tight">
-              {title}
-            </h1>
+            <h1 className="text-3xl font-bold text-primary  tracking-tight">{title}</h1>
             {count !== undefined && (
               <motion.span
                 initial={{ scale: 0 }}
@@ -63,11 +61,7 @@ export const SimpleSectionHeader = ({
               </motion.span>
             )}
           </div>
-          {subtitle && (
-            <p className="text-gray-600 dark:text-gray-300 text-lg leading-relaxed max-w-2xl">
-              {subtitle}
-            </p>
-          )}
+          {subtitle && <p className="text-muted  text-lg leading-relaxed max-w-2xl">{subtitle}</p>}
         </div>
 
         {action && (

--- a/app/(features)/bookmarks/last-read/page.tsx
+++ b/app/(features)/bookmarks/last-read/page.tsx
@@ -4,10 +4,10 @@ import { SettingsSidebar } from '@/app/(features)/surah/[surahId]/components/Set
 
 export default function LastReadPage() {
   return (
-    <div className="flex flex-grow bg-white dark:bg-[var(--background)] text-[var(--foreground)] overflow-hidden">
-      <main className="flex-grow p-6 lg:p-10 overflow-y-auto homepage-scrollable-area">
+    <div className="flex flex-grow bg-surface text-primary overflow-hidden">
+      <main className="flex-grow section overflow-y-auto homepage-scrollable-area">
         <h1 className="text-2xl font-bold mb-6">Last Read</h1>
-        <p className="text-gray-500">No last read verse.</p>
+        <p className="text-muted">No last read verse.</p>
       </main>
       <SettingsSidebar
         onTranslationPanelOpen={() => {}}

--- a/app/(features)/bookmarks/page.tsx
+++ b/app/(features)/bookmarks/page.tsx
@@ -3,72 +3,100 @@
 import React, { useState, useMemo } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useBookmarks } from '@/app/providers/BookmarkContext';
-import { PinIcon, ClockIcon, FolderIcon, EllipsisHIcon, SearchIcon, PlusIcon } from '@/app/shared/icons';
+import {
+  PinIcon,
+  ClockIcon,
+  FolderIcon,
+  EllipsisHIcon,
+  SearchIcon,
+  PlusIcon,
+} from '@/app/shared/icons';
 import { CreateFolderModal } from './components/CreateFolderModal';
 import { BookmarkListView } from './components/BookmarkListView';
 
 // ===== Reusable Components =====
 
-const SidebarItem = ({ icon: Icon, label, isActive }: { icon: React.ElementType, label: string, isActive?: boolean }) => (
-  <a
-    href="#"
+const SidebarItem = ({
+  icon: Icon,
+  label,
+  isActive,
+}: {
+  icon: React.ElementType;
+  label: string;
+  isActive?: boolean;
+}) => (
+  <button
+    type="button"
     className={`flex items-center space-x-3 rounded-lg px-3 py-2 text-sm font-medium ${
-      isActive
-        ? 'bg-teal-100 text-teal-900 dark:bg-teal-900 dark:text-white'
-        : 'text-gray-700 hover:bg-gray-200 dark:text-gray-300 dark:hover:bg-gray-700'
+      isActive ? 'bg-teal-100 text-teal-900 dark:bg-teal-900 ' : 'text-primary hover:bg-surface/50'
     }`}
   >
     <Icon className="h-5 w-5" />
     <span>{label}</span>
-  </a>
+  </button>
 );
 
-const FolderCard = ({ name, count, color, onClick }: { name: string, count: number, color: string, onClick: () => void }) => (
+const FolderCard = ({
+  name,
+  count,
+  color,
+  onClick,
+}: {
+  name: string;
+  count: number;
+  color: string;
+  onClick: () => void;
+}) => (
   <motion.div
     layout
     initial={{ opacity: 0, scale: 0.8 }}
     animate={{ opacity: 1, scale: 1 }}
     exit={{ opacity: 0, scale: 0.8 }}
     transition={{ type: 'spring', stiffness: 300, damping: 30 }}
-    className="group relative cursor-pointer rounded-lg border border-gray-200 bg-white p-4 hover:shadow-md dark:border-gray-700 dark:bg-gray-800"
+    className="group relative cursor-pointer card hover:shadow-md"
     onClick={onClick}
   >
     <div className="flex items-center space-x-3">
       <FolderIcon size={24} className={color} />
       <div>
-        <h3 className="font-semibold text-gray-800 dark:text-white">{name}</h3>
-        <p className="text-sm text-gray-500 dark:text-gray-400">{count} Bookmarks</p>
+        <h3 className="font-semibold text-primary ">{name}</h3>
+        <p className="text-sm text-muted ">{count} Bookmarks</p>
       </div>
     </div>
-    <button className="absolute right-2 top-2 rounded-full p-1 text-gray-500 hover:bg-gray-200 group-hover:opacity-100 dark:hover:bg-gray-700 md:opacity-0" onClick={(e) => e.stopPropagation()}>
+    <button
+      className="absolute right-2 top-2 rounded-full p-1 text-muted hover:bg-surface/50 group-hover:opacity-100 md:opacity-0"
+      onClick={(e) => e.stopPropagation()}
+    >
       <EllipsisHIcon size={20} />
     </button>
   </motion.div>
 );
 
 const ContentHeader = ({ onNewFolderClick }: { onNewFolderClick: () => void }) => (
-    <div className="mb-6 flex flex-wrap items-center justify-between gap-4">
-        <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Bookmarks</h1>
-        <div className="flex items-center space-x-2">
-            <button
-              onClick={onNewFolderClick}
-              className="flex items-center space-x-2 rounded-md bg-teal-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-teal-700"
-            >
-              <PlusIcon size={16} />
-              <span>New Folder</span>
-            </button>
-            <div className="relative">
-                <SearchIcon size={18} className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" />
-                <input
-                    type="text"
-                    placeholder="Search Bookmarks"
-                    className="w-48 rounded-md border-gray-300 bg-gray-100 py-1.5 pl-9 pr-3 text-sm focus:border-teal-500 focus:ring-teal-500 dark:border-gray-600 dark:bg-gray-700"
-                />
-            </div>
-        </div>
+  <div className="mb-6 flex flex-wrap items-center justify-between gap-4">
+    <h1 className="text-2xl font-bold text-primary ">Bookmarks</h1>
+    <div className="flex items-center space-x-2">
+      <button
+        onClick={onNewFolderClick}
+        className="flex items-center space-x-2 rounded-md bg-teal-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-teal-700"
+      >
+        <PlusIcon size={16} />
+        <span>New Folder</span>
+      </button>
+      <div className="relative">
+        <SearchIcon
+          size={18}
+          className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted"
+        />
+        <input
+          type="text"
+          placeholder="Search Bookmarks"
+          className="w-48 rounded-md border-gray-300 bg-gray-100 py-1.5 pl-9 pr-3 text-sm focus:border-teal-500 focus:ring-teal-500 dark:border-gray-600 "
+        />
+      </div>
     </div>
+  </div>
 );
-
 
 // ===== Main Page Component =====
 
@@ -79,19 +107,25 @@ const BookmarksPage = () => {
 
   const selectedFolder = useMemo(() => {
     if (!selectedFolderId) return null;
-    return folders.find(f => f.id === selectedFolderId) || null;
+    return folders.find((f) => f.id === selectedFolderId) || null;
   }, [selectedFolderId, folders]);
 
-  const colors = ['text-pink-500', 'text-indigo-500', 'text-green-500', 'text-yellow-500', 'text-blue-500'];
+  const colors = [
+    'text-pink-500',
+    'text-indigo-500',
+    'text-green-500',
+    'text-yellow-500',
+    'text-blue-500',
+  ];
 
   return (
     <>
       <CreateFolderModal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} />
-      <div className="flex h-full w-full bg-white dark:bg-gray-900">
+      <div className="flex h-full w-full bg-surface ">
         {/* Left Sidebar for Bookmark Navigation */}
-        <aside className="w-72 flex-shrink-0 border-r border-gray-200 bg-slate-50 p-4 dark:border-gray-700 dark:bg-slate-800/50">
+        <aside className="w-72 flex-shrink-0 border-r border-gray-200 bg-slate-50 p-4 dark:border-gray-700 ">
           <div className="space-y-4">
-            <h1 className="px-3 text-xl font-bold text-gray-900 dark:text-white">Bookmarks</h1>
+            <h1 className="px-3 text-xl font-bold text-primary ">Bookmarks</h1>
             <nav className="space-y-1">
               <SidebarItem icon={PinIcon} label="Bookmarks" isActive={true} />
               <SidebarItem icon={PinIcon} label="Pin Ayah" />
@@ -101,7 +135,7 @@ const BookmarksPage = () => {
         </aside>
 
         {/* Main Content Area */}
-        <main className="flex-1 overflow-y-auto p-6">
+        <main className="flex-1 overflow-y-auto section">
           <AnimatePresence mode="wait">
             {selectedFolder ? (
               <BookmarkListView
@@ -131,9 +165,9 @@ const BookmarksPage = () => {
                   </AnimatePresence>
                 </motion.div>
                 {folders.length === 0 && (
-                  <div className="mt-10 text-center text-gray-500">
-                      <p>No folders yet.</p>
-                      <p>Click "New Folder" to get started.</p>
+                  <div className="mt-10 text-center text-muted">
+                    <p>No folders yet.</p>
+                    <p>Click &quot;New Folder&quot; to get started.</p>
                   </div>
                 )}
               </motion.div>
@@ -143,6 +177,6 @@ const BookmarksPage = () => {
       </div>
     </>
   );
-}
+};
 
 export default BookmarksPage;

--- a/app/(features)/bookmarks/pinned/page.tsx
+++ b/app/(features)/bookmarks/pinned/page.tsx
@@ -4,10 +4,10 @@ import { SettingsSidebar } from '@/app/(features)/surah/[surahId]/components/Set
 
 export default function PinnedAyahPage() {
   return (
-    <div className="flex flex-grow bg-white dark:bg-[var(--background)] text-[var(--foreground)] overflow-hidden">
-      <main className="flex-grow p-6 lg:p-10 overflow-y-auto homepage-scrollable-area">
+    <div className="flex flex-grow bg-surface text-primary overflow-hidden">
+      <main className="flex-grow section overflow-y-auto homepage-scrollable-area">
         <h1 className="text-2xl font-bold mb-6">Pin Ayah</h1>
-        <p className="text-gray-500">No pinned verses.</p>
+        <p className="text-muted">No pinned verses.</p>
       </main>
       <SettingsSidebar
         onTranslationPanelOpen={() => {}}

--- a/app/(features)/bookmarks/styles.ts
+++ b/app/(features)/bookmarks/styles.ts
@@ -3,7 +3,7 @@ import css from 'styled-jsx/css';
 export default css.global`
   @layer components {
     .bm-heading {
-      @apply text-gray-900 dark:text-white font-bold tracking-tight;
+      @apply text-primary  font-bold tracking-tight;
     }
     .bm-section {
       @apply py-8 space-y-6;
@@ -39,7 +39,7 @@ export default css.global`
       @apply bg-teal-600 hover:bg-teal-700 text-white px-4 py-2.5 rounded-xl font-medium transition-all duration-200 transform hover:scale-105 focus:scale-105 focus:outline-none focus:ring-2 focus:ring-teal-500 focus:ring-offset-2 shadow-lg shadow-teal-600/25 hover:shadow-teal-600/40;
     }
     .bm-button-ghost {
-      @apply text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white hover:bg-gray-100 dark:hover:bg-gray-800 px-4 py-2 rounded-lg transition-colors;
+      @apply text-muted  hover:text-primary dark:hover:text-white hover:bg-gray-100 hover:bg-surface/50 px-4 py-2 rounded-lg transition-colors;
     }
   }
 `;

--- a/app/(features)/home/components/HomeHeader.tsx
+++ b/app/(features)/home/components/HomeHeader.tsx
@@ -8,7 +8,7 @@ export default function HomeHeader() {
   return (
     <header className="w-full py-4">
       <nav
-        className={`flex justify-between items-center max-w-screen-2xl mx-auto p-3 sm:p-4 rounded-2xl backdrop-blur-xl shadow-lg hover:shadow-xl transition-all duration-300 ${theme === 'light' ? 'bg-white/60' : 'bg-slate-800/50'}`}
+        className={`flex justify-between items-center max-w-screen-2xl mx-auto p-3 sm:p-4 rounded-2xl backdrop-blur-xl shadow-lg hover:shadow-xl transition-all duration-300 ${theme === 'light' ? 'bg-surface/60' : 'bg-slate-800/50'}`}
       >
         <h1
           className={`text-2xl font-bold tracking-wider ${theme === 'light' ? 'text-slate-900' : 'text-white'}`}
@@ -17,7 +17,7 @@ export default function HomeHeader() {
         </h1>
         <button
           onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
-          className="p-2 bg-white/40 dark:bg-white/10 rounded-full hover:bg-white/60 dark:hover:bg-white/20 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500"
+          className="p-2 bg-surface/40 dark:bg-surface/10 rounded-full hover:bg-surface/60 dark:hover:bg-surface/20 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500"
           aria-label="Toggle Theme"
         >
           {theme === 'light' ? (

--- a/app/(features)/home/components/HomePage.tsx
+++ b/app/(features)/home/components/HomePage.tsx
@@ -26,7 +26,7 @@ export default function HomePage() {
 
   return (
     <div
-      className={`relative h-screen flex flex-col ${theme === 'light' ? 'bg-white text-slate-900' : 'bg-transparent dark:text-[var(--foreground)]'} overflow-hidden`}
+      className={`relative h-screen flex flex-col ${theme === 'light' ? 'bg-surface text-slate-900' : 'bg-transparent '} overflow-hidden`}
     >
       <HomePageBackground />
 

--- a/app/(features)/home/components/HomePageBackground.tsx
+++ b/app/(features)/home/components/HomePageBackground.tsx
@@ -3,7 +3,7 @@
  */
 export default function HomePageBackground() {
   return (
-    <div className="fixed inset-0 -z-10 bg-white bg-gradient-to-br from-cyan-50 via-white to-emerald-50 dark:bg-gray-900 dark:from-gray-900 dark:via-gray-900 dark:to-slate-900">
+    <div className="fixed inset-0 -z-10 bg-surface bg-gradient-to-br from-cyan-50 via-white to-emerald-50  dark:from-gray-900 dark:via-gray-900 dark:to-slate-900">
       {/* Decorative Blobs */}
       <div className="absolute top-[-10rem] right-[-10rem] h-72 w-72 rounded-full bg-emerald-400/20 filter blur-3xl opacity-50 dark:bg-emerald-500/10"></div>
       <div className="absolute bottom-[-5rem] left-[-10rem] h-80 w-80 rounded-full bg-cyan-400/20 filter blur-3xl opacity-40 dark:bg-cyan-500/10"></div>

--- a/app/(features)/home/components/HomeSearch.tsx
+++ b/app/(features)/home/components/HomeSearch.tsx
@@ -13,15 +13,15 @@ export default function HomeSearch({ searchQuery, setSearchQuery }: HomeSearchPr
 
   const searchBarClasses =
     theme === 'light'
-      ? 'bg-white text-gray-700 border-none placeholder-gray-400'
-      : 'bg-gray-800 text-gray-200 border-none placeholder-gray-400';
+      ? 'bg-surface text-primary border-none placeholder-gray-400'
+      : 'bg-gray-800 text-muted border-none placeholder-gray-400';
 
   return (
     <>
       <div className="mt-10 w-full max-w-2xl mx-auto content-visibility-auto animate-fade-in-up animation-delay-200">
         <div className="relative">
           <SearchSolidIcon
-            className="absolute left-4 top-1/2 -translate-y-1/2 text-gray-400"
+            className="absolute left-4 top-1/2 -translate-y-1/2 text-muted"
             size={20}
           />
           <input
@@ -29,7 +29,7 @@ export default function HomeSearch({ searchQuery, setSearchQuery }: HomeSearchPr
             placeholder="What do you want to read?"
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            className={`w-full pl-12 pr-4 py-3 rounded-lg ring-0 focus:outline-none focus:ring-0 transition-all duration-300 hover:shadow-lg text-lg ${searchBarClasses} backdrop-blur-xl shadow-lg hover:shadow-xl ${theme === 'light' ? 'bg-white/60' : 'bg-slate-800/50'} animate-fade-in-up animation-delay-200`}
+            className={`w-full pl-12 pr-4 py-3 rounded-lg ring-0 focus:outline-none focus:ring-0 transition-all duration-300 hover:shadow-lg text-lg ${searchBarClasses} backdrop-blur-xl shadow-lg hover:shadow-xl ${theme === 'light' ? 'bg-surface/60' : 'bg-slate-800/50'} animate-fade-in-up animation-delay-200`}
           />
         </div>
       </div>
@@ -40,7 +40,7 @@ export default function HomeSearch({ searchQuery, setSearchQuery }: HomeSearchPr
             key={name}
             className={`px-4 sm:px-5 py-2 rounded-full font-medium shadow-sm transition-all duration-200 ${
               theme === 'light'
-                ? 'bg-white border border-gray-200 text-slate-800 hover:bg-gray-100 hover:shadow-md'
+                ? 'bg-surface border border-gray-200 text-slate-800 hover:bg-gray-100 hover:shadow-md'
                 : 'bg-slate-800/40 border-slate-700/50 text-slate-300 backdrop-blur-md hover:bg-slate-700/60 hover:scale-105 transform hover:shadow-md'
             }`}
           >

--- a/app/(features)/home/components/HomeTabs.tsx
+++ b/app/(features)/home/components/HomeTabs.tsx
@@ -16,7 +16,7 @@ export default function HomeTabs({ searchQuery }: HomeTabsProps) {
   return (
     <section id="surahs" className="py-20 max-w-screen-2xl mx-auto w-full">
       <div className="flex justify-between items-center mb-8 content-visibility-auto animate-fade-in-up animation-delay-600">
-        <h2 className="text-3xl font-bold text-slate-900 dark:text-white">All Surahs</h2>
+        <h2 className="text-3xl font-bold text-slate-900 ">All Surahs</h2>
         <div
           className={`flex items-center p-1 sm:p-2 rounded-full ${theme === 'light' ? 'bg-gray-100' : 'bg-slate-800/60'}`}
         >
@@ -25,7 +25,7 @@ export default function HomeTabs({ searchQuery }: HomeTabsProps) {
             className={`px-4 sm:px-5 py-2 rounded-full text-sm font-semibold transition-colors ${
               activeTab === 'Surah'
                 ? theme === 'light'
-                  ? 'bg-white shadow text-slate-900'
+                  ? 'bg-surface shadow text-slate-900'
                   : 'bg-slate-700 text-white shadow'
                 : theme === 'light'
                   ? 'text-slate-500 hover:text-slate-800'
@@ -39,7 +39,7 @@ export default function HomeTabs({ searchQuery }: HomeTabsProps) {
             className={`px-4 sm:px-5 py-2 rounded-full text-sm font-semibold transition-colors ${
               activeTab === 'Juz'
                 ? theme === 'light'
-                  ? 'bg-white shadow text-slate-900'
+                  ? 'bg-surface shadow text-slate-900'
                   : 'bg-slate-700 text-white shadow'
                 : theme === 'light'
                   ? 'text-slate-500 hover:text-slate-800'
@@ -53,7 +53,7 @@ export default function HomeTabs({ searchQuery }: HomeTabsProps) {
             className={`px-4 sm:px-5 py-2 rounded-full text-sm font-semibold transition-colors ${
               activeTab === 'Page'
                 ? theme === 'light'
-                  ? 'bg-white shadow text-slate-900'
+                  ? 'bg-surface shadow text-slate-900'
                   : 'bg-slate-700 text-white shadow'
                 : theme === 'light'
                   ? 'text-slate-500 hover:text-slate-800'

--- a/app/(features)/home/components/JuzTab.tsx
+++ b/app/(features)/home/components/JuzTab.tsx
@@ -20,7 +20,7 @@ export default function JuzTab() {
         <Link
           href={`/juz/${juz.number}`}
           key={juz.number}
-          className={`group p-4 sm:p-5 rounded-2xl backdrop-blur-xl shadow-lg hover:shadow-xl transition-all duration-300 content-visibility-auto animate-fade-in-up ${theme === 'light' ? 'bg-white/60' : 'bg-slate-800/40'}`}
+          className={`group p-4 sm:p-5 rounded-2xl backdrop-blur-xl shadow-lg hover:shadow-xl transition-all duration-300 content-visibility-auto animate-fade-in-up ${theme === 'light' ? 'bg-surface/60' : 'bg-slate-800/40'}`}
         >
           <div className="flex items-center justify-between">
             <div className="flex items-center space-x-4">

--- a/app/(features)/home/components/PageTab.tsx
+++ b/app/(features)/home/components/PageTab.tsx
@@ -13,7 +13,7 @@ export default function PageTab() {
         <Link
           href={`/page/${page}`}
           key={page}
-          className={`group p-4 sm:p-5 rounded-2xl backdrop-blur-xl shadow-lg hover:shadow-xl transition-all duration-300 content-visibility-auto animate-fade-in-up ${theme === 'light' ? 'bg-white/60' : 'bg-slate-800/40'}`}
+          className={`group p-4 sm:p-5 rounded-2xl backdrop-blur-xl shadow-lg hover:shadow-xl transition-all duration-300 content-visibility-auto animate-fade-in-up ${theme === 'light' ? 'bg-surface/60' : 'bg-slate-800/40'}`}
         >
           <div className="flex items-center space-x-4">
             <div

--- a/app/(features)/home/components/SurahTab.tsx
+++ b/app/(features)/home/components/SurahTab.tsx
@@ -51,7 +51,7 @@ export default function SurahTab({ searchQuery }: SurahTabProps) {
         <Link
           href={`/surah/${surah.number}`}
           key={surah.number}
-          className={`group p-4 sm:p-5 rounded-2xl backdrop-blur-xl shadow-lg hover:shadow-xl transition-all duration-300 content-visibility-auto animate-fade-in-up ${theme === 'light' ? 'bg-white/60' : 'bg-slate-800/40'}`}
+          className={`group p-4 sm:p-5 rounded-2xl backdrop-blur-xl shadow-lg hover:shadow-xl transition-all duration-300 content-visibility-auto animate-fade-in-up ${theme === 'light' ? 'bg-surface/60' : 'bg-slate-800/40'}`}
         >
           <div className="flex items-center justify-between">
             <div className="flex items-center space-x-4">

--- a/app/(features)/home/components/ThemedCard.tsx
+++ b/app/(features)/home/components/ThemedCard.tsx
@@ -16,7 +16,7 @@ export default function ThemedCard({ href, children, className = '' }: ThemedCar
   return (
     <Link
       href={href}
-      className={`group p-4 sm:p-5 rounded-2xl backdrop-blur-xl shadow-lg hover:shadow-xl transition-all duration-300 content-visibility-auto animate-fade-in-up ${theme === 'light' ? 'bg-white/60' : 'bg-slate-800/40'} ${className}`}
+      className={`group p-4 sm:p-5 rounded-2xl backdrop-blur-xl shadow-lg hover:shadow-xl transition-all duration-300 content-visibility-auto animate-fade-in-up ${theme === 'light' ? 'bg-surface/60' : 'bg-slate-800/40'} ${className}`}
     >
       {children}
     </Link>

--- a/app/(features)/home/components/VerseOfDay.tsx
+++ b/app/(features)/home/components/VerseOfDay.tsx
@@ -145,7 +145,7 @@ export default function VerseOfDay() {
 
   return (
     <div
-      className={`mt-12 w-full max-w-4xl p-4 sm:p-6 md:p-8 rounded-2xl shadow-lg backdrop-blur-xl content-visibility-auto animate-fade-in-up animation-delay-400 ${theme === 'light' ? 'bg-white/60' : 'bg-slate-800/30'}`}
+      className={`mt-12 w-full max-w-4xl p-4 sm:p-6 md:p-8 rounded-2xl shadow-lg backdrop-blur-xl content-visibility-auto animate-fade-in-up animation-delay-400 ${theme === 'light' ? 'bg-surface/60' : 'bg-slate-800/30'}`}
     >
       {content}
     </div>

--- a/app/(features)/juz/[juzId]/components/JuzHeader.tsx
+++ b/app/(features)/juz/[juzId]/components/JuzHeader.tsx
@@ -10,7 +10,7 @@ export function JuzHeader({ juz }: JuzHeaderProps) {
   if (!juz) return null;
   return (
     <div className="mb-8 text-center">
-      <h1 className="text-3xl font-bold text-[var(--foreground)]">
+      <h1 className="text-3xl font-bold text-primary">
         {t('juz_number', { number: juz.juz_number })}
       </h1>
     </div>

--- a/app/(features)/juz/[juzId]/components/JuzVerseList.tsx
+++ b/app/(features)/juz/[juzId]/components/JuzVerseList.tsx
@@ -19,7 +19,7 @@ export function JuzVerseList({
   const { t } = useTranslation();
 
   if (verses.length === 0) {
-    return <div className="text-center py-20 text-gray-500">{t('no_verses_found_in_juz')}</div>;
+    return <div className="text-center py-20 text-muted">{t('no_verses_found_in_juz')}</div>;
   }
 
   return (
@@ -29,7 +29,7 @@ export function JuzVerseList({
       ))}
       <div ref={loadMoreRef} className="py-4 text-center">
         {isValidating && <span className="text-teal-600">{t('loading')}</span>}
-        {isReachingEnd && <span className="text-gray-500">{t('end_of_juz')}</span>}
+        {isReachingEnd && <span className="text-muted">{t('end_of_juz')}</span>}
       </div>
     </>
   );

--- a/app/(features)/juz/[juzId]/page.tsx
+++ b/app/(features)/juz/[juzId]/page.tsx
@@ -80,8 +80,8 @@ export default function JuzPage({ params }: { params: Promise<{ juzId: string }>
     : null;
 
   return (
-    <div className="flex flex-grow bg-white dark:bg-[var(--background)] text-[var(--foreground)] font-sans overflow-hidden min-h-0">
-      <main className="flex-grow bg-white dark:bg-[var(--background)] p-6 lg:p-10 overflow-y-auto homepage-scrollable-area">
+    <div className="flex flex-grow bg-surface text-primary font-sans overflow-hidden min-h-0">
+      <main className="flex-grow bg-surface section overflow-y-auto homepage-scrollable-area">
         <div className="w-full relative">
           {juzId ? (
             isLoading ? (

--- a/app/(features)/page/[pageId]/page.tsx
+++ b/app/(features)/page/[pageId]/page.tsx
@@ -81,8 +81,8 @@ export default function PagePage({ params }: PagePageProps) {
     : null;
 
   return (
-    <div className="flex flex-grow bg-white dark:bg-[var(--background)] text-[var(--foreground)] font-sans overflow-hidden">
-      <main className="flex-grow bg-white dark:bg-[var(--background)] p-6 lg:p-10 overflow-y-auto homepage-scrollable-area">
+    <div className="flex flex-grow bg-surface text-primary font-sans overflow-hidden">
+      <main className="flex-grow bg-surface section overflow-y-auto homepage-scrollable-area">
         <div className="w-full relative">
           {isLoading ? (
             <div className="flex justify-center py-20">
@@ -99,11 +99,11 @@ export default function PagePage({ params }: PagePageProps) {
               ))}
               <div ref={loadMoreRef} className="py-4 text-center space-x-2">
                 {isValidating && <Spinner className="inline h-5 w-5 text-teal-600" />}
-                {isReachingEnd && <span className="text-gray-500">{t('end_of_page')}</span>}
+                {isReachingEnd && <span className="text-muted">{t('end_of_page')}</span>}
               </div>
             </>
           ) : (
-            <div className="text-center py-20 text-gray-500">{t('no_verses_found_on_page')}</div>
+            <div className="text-center py-20 text-muted">{t('no_verses_found_on_page')}</div>
           )}
         </div>
       </main>

--- a/app/(features)/search/page.tsx
+++ b/app/(features)/search/page.tsx
@@ -33,7 +33,7 @@ function SearchContent() {
       {loading && <p className="text-teal-600">Loading...</p>}
       {error && <p className="text-red-600 mb-4">{error}</p>}
       {!loading && verses.length === 0 && !error && query && (
-        <p className="text-gray-500">No verses found.</p>
+        <p className="text-muted">No verses found.</p>
       )}
       <div className="space-y-8">
         {verses.map((v) => (

--- a/app/(features)/surah/[surahId]/components/ArabicFontPanel.tsx
+++ b/app/(features)/surah/[surahId]/components/ArabicFontPanel.tsx
@@ -66,7 +66,7 @@ export const ArabicFontPanel: React.FC<ArabicFontPanelProps> = ({ isOpen, onClos
       data-testid="arabic-font-panel"
       className={`absolute inset-0 flex flex-col transition-transform duration-300 ease-in-out z-50 shadow-lg ${
         isOpen ? 'translate-x-0' : 'translate-x-full'
-      } ${theme === 'dark' ? 'bg-[var(--background)] text-[var(--foreground)]' : 'bg-white text-slate-800'}`}
+      } ${theme === 'dark' ? 'bg-surface text-primary' : 'bg-surface text-slate-800'}`}
     >
       <header
         className={`flex items-center p-4 border-b ${
@@ -81,7 +81,7 @@ export const ArabicFontPanel: React.FC<ArabicFontPanelProps> = ({ isOpen, onClos
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
-            className={`h-6 w-6 ${theme === 'dark' ? 'text-[var(--foreground)]' : 'text-slate-600'}`}
+            className={`h-6 w-6 ${theme === 'dark' ? 'text-primary' : 'text-slate-600'}`}
             fill="none"
             viewBox="0 0 24 24"
             stroke="currentColor"
@@ -92,7 +92,7 @@ export const ArabicFontPanel: React.FC<ArabicFontPanelProps> = ({ isOpen, onClos
         </button>
         <h2
           className={`text-lg font-bold text-center flex-grow ${
-            theme === 'dark' ? 'text-[var(--foreground)]' : 'text-slate-800'
+            theme === 'dark' ? 'text-primary' : 'text-slate-800'
           }`}
         >
           Arabic Font Selection
@@ -101,7 +101,7 @@ export const ArabicFontPanel: React.FC<ArabicFontPanelProps> = ({ isOpen, onClos
           onClick={handleReset}
           className={`p-2 rounded-full focus-visible:outline-none transition-colors ${
             theme === 'dark'
-              ? 'text-[var(--foreground)] hover:bg-gray-700'
+              ? 'text-primary hover:bg-gray-700'
               : 'text-slate-500 hover:bg-slate-100 hover:text-slate-700'
           }`}
           title="Reset to Default"
@@ -140,13 +140,12 @@ export const ArabicFontPanel: React.FC<ArabicFontPanelProps> = ({ isOpen, onClos
           <>
             {/* Scrollable Content - Toggle and List */}
             <div className="flex-1 overflow-y-auto" ref={listContainerRef}>
-
               {/* Font Type Toggle - Uthmani/Indopak */}
               <div
                 className={`sticky top-0 z-10 py-4 border-b ${
                   theme === 'dark'
-                    ? 'bg-[var(--background)] border-[var(--border-color)]'
-                    : 'bg-white/95 backdrop-blur-sm border-slate-200'
+                    ? 'bg-surface border-[var(--border-color)]'
+                    : 'bg-surface/95 backdrop-blur-sm border-slate-200'
                 }`}
               >
                 <div className="px-4">
@@ -161,7 +160,7 @@ export const ArabicFontPanel: React.FC<ArabicFontPanelProps> = ({ isOpen, onClos
                         activeFilter === 'Uthmani'
                           ? theme === 'dark'
                             ? 'bg-slate-700 text-white shadow'
-                            : 'bg-white shadow text-slate-900'
+                            : 'bg-surface shadow text-slate-900'
                           : theme === 'dark'
                             ? 'text-slate-400 hover:text-white'
                             : 'text-slate-400 hover:text-slate-700'
@@ -175,7 +174,7 @@ export const ArabicFontPanel: React.FC<ArabicFontPanelProps> = ({ isOpen, onClos
                         activeFilter === 'IndoPak'
                           ? theme === 'dark'
                             ? 'bg-slate-700 text-white shadow'
-                            : 'bg-white shadow text-slate-900'
+                            : 'bg-surface shadow text-slate-900'
                           : theme === 'dark'
                             ? 'text-slate-400 hover:text-white'
                             : 'text-slate-400 hover:text-slate-700'

--- a/app/(features)/surah/[surahId]/components/CollapsibleSection.tsx
+++ b/app/(features)/surah/[surahId]/components/CollapsibleSection.tsx
@@ -26,11 +26,11 @@ export const CollapsibleSection = ({
       <button onClick={onToggle} className="w-full flex items-center justify-between p-4 text-left">
         <div className="flex items-center space-x-3">
           {icon}
-          <span className="font-semibold text-[var(--foreground)]">{title}</span>
+          <span className="font-semibold text-primary">{title}</span>
         </div>
         <ChevronDownIcon
           size={16}
-          className={`text-gray-500 transition-transform duration-300 ${isOpen ? 'rotate-180' : ''}`}
+          className={`text-muted transition-transform duration-300 ${isOpen ? 'rotate-180' : ''}`}
         />
       </button>
       <div

--- a/app/(features)/surah/[surahId]/components/FontSettings.tsx
+++ b/app/(features)/surah/[surahId]/components/FontSettings.tsx
@@ -38,7 +38,7 @@ export const FontSettings = ({
       <div className="space-y-4">
         <div>
           <div className="flex justify-between mb-1 text-sm">
-            <label className="text-[var(--foreground)]">{t('arabic_font_size')}</label>
+            <label className="text-primary">{t('arabic_font_size')}</label>
             <span className="font-semibold text-teal-700">{settings.arabicFontSize}</span>
           </div>
           <input
@@ -52,7 +52,7 @@ export const FontSettings = ({
         </div>
         <div>
           <div className="flex justify-between mb-1 text-sm">
-            <label className="text-[var(--foreground)]">{t('translation_font_size')}</label>
+            <label className="text-primary">{t('translation_font_size')}</label>
             <span className="font-semibold text-teal-700">{settings.translationFontSize}</span>
           </div>
           <input

--- a/app/(features)/surah/[surahId]/components/ReadingSettings.tsx
+++ b/app/(features)/surah/[surahId]/components/ReadingSettings.tsx
@@ -21,7 +21,7 @@ export const ReadingSettings = ({ isOpen = false, onToggle }: ReadingSettingsPro
       isOpen={isOpen}
       onToggle={onToggle || (() => {})}
     >
-      <div className="text-center py-8 text-gray-500">Coming soon...</div>
+      <div className="text-center py-8 text-muted">Coming soon...</div>
     </CollapsibleSection>
   );
 };

--- a/app/(features)/surah/[surahId]/components/SettingsSidebar.tsx
+++ b/app/(features)/surah/[surahId]/components/SettingsSidebar.tsx
@@ -15,7 +15,7 @@ import { TranslationPanel } from './translation-panel';
 import { TafsirPanel } from './tafsir-panel';
 import { WordLanguagePanel } from './WordLanguagePanel';
 
-interface SettingsSidebarProps {
+export interface SettingsSidebarProps {
   onTranslationPanelOpen: () => void;
   onWordLanguagePanelOpen: () => void;
   onTafsirPanelOpen?: () => void;
@@ -69,7 +69,7 @@ export const SettingsSidebar = ({
     } catch (error) {
       console.warn('Failed to parse saved sidebar sections:', error);
     }
-    
+
     // Default open sections - both translation and font should be open by default
     return ['translation', 'font'];
   });
@@ -79,7 +79,7 @@ export const SettingsSidebar = ({
     console.log('Toggling section:', sectionId, 'Current open:', openSections);
     setOpenSections((prev) => {
       let newState: string[];
-      
+
       if (prev.includes(sectionId)) {
         // If section is open, close it
         newState = prev.filter((id) => id !== sectionId);
@@ -95,14 +95,14 @@ export const SettingsSidebar = ({
         }
         console.log('Opening section, new state:', newState);
       }
-      
+
       // Save to localStorage
       try {
         localStorage.setItem('settings-sidebar-open-sections', JSON.stringify(newState));
       } catch (error) {
         console.warn('Failed to save sidebar sections to localStorage:', error);
       }
-      
+
       return newState;
     });
   };
@@ -157,7 +157,7 @@ export const SettingsSidebar = ({
       />
       <aside
         ref={sidebarRef}
-        className={`settings-sidebar fixed lg:static top-16 lg:top-0 bottom-0 right-0 w-[20.7rem] bg-[var(--background)] text-[var(--foreground)] flex-col flex-shrink-0 overflow-y-auto overflow-x-hidden shadow-[-5px_0px_15px_-5px_rgba(0,0,0,0.05)] transition-all duration-300 z-40 lg:z-40 lg:h-full ${
+        className={`settings-sidebar fixed lg:static top-16 lg:top-0 bottom-0 right-0 w-[20.7rem] bg-surface text-primary flex-col flex-shrink-0 overflow-y-auto overflow-x-hidden shadow-[-5px_0px_15px_-5px_rgba(0,0,0,0.05)] transition-all duration-300 z-40 lg:z-40 lg:h-full ${
           isSettingsOpen ? 'translate-x-0' : 'translate-x-full'
         } lg:translate-x-0 ${isSettingsOpen ? 'flex' : 'hidden'} lg:flex scrollbar-hide`}
         style={{
@@ -174,9 +174,7 @@ export const SettingsSidebar = ({
           >
             <ArrowLeftIcon size={18} />
           </button>
-          <h2 className="flex-grow text-center text-lg font-bold">
-            Settings
-          </h2>
+          <h2 className="flex-grow text-center text-lg font-bold">Settings</h2>
           <div className="w-8" />
         </header>
         <div className="flex-grow p-4 space-y-4">
@@ -188,7 +186,7 @@ export const SettingsSidebar = ({
               className={`w-1/2 px-4 py-2 rounded-full text-sm font-semibold transition-colors ${
                 activeTab === 'translation'
                   ? theme === 'light'
-                    ? 'bg-white shadow text-slate-900'
+                    ? 'bg-surface shadow text-slate-900'
                     : 'bg-slate-700 text-white shadow'
                   : theme === 'light'
                     ? 'text-slate-400 hover:text-slate-700'
@@ -202,7 +200,7 @@ export const SettingsSidebar = ({
               className={`w-1/2 px-4 py-2 rounded-full text-sm font-semibold transition-colors ${
                 activeTab === 'reading'
                   ? theme === 'light'
-                    ? 'bg-white shadow text-slate-900'
+                    ? 'bg-surface shadow text-slate-900'
                     : 'bg-slate-700 text-white shadow'
                   : theme === 'light'
                     ? 'text-slate-400 hover:text-slate-700'
@@ -240,7 +238,7 @@ export const SettingsSidebar = ({
             </>
           )}
           {activeTab === 'reading' && (
-            <div className="text-center py-8 text-gray-500">
+            <div className="text-center py-8 text-muted">
               Mushaf settings have been moved to the Translation tab.
             </div>
           )}
@@ -255,7 +253,7 @@ export const SettingsSidebar = ({
               onClick={() => setTheme('light')}
               className={`w-1/2 px-4 py-2 rounded-full text-sm font-semibold transition-colors ${
                 theme === 'light'
-                  ? 'bg-white shadow text-slate-900'
+                  ? 'bg-surface shadow text-slate-900'
                   : 'text-slate-400 hover:text-white'
               }`}
             >
@@ -284,10 +282,7 @@ export const SettingsSidebar = ({
           <TafsirPanel isOpen={isTafsirPanelOpen} onClose={onTafsirPanelClose} />
         )}
         {onWordLanguagePanelClose && (
-          <WordLanguagePanel 
-            isOpen={isWordLanguagePanelOpen} 
-            onClose={onWordLanguagePanelClose} 
-          />
+          <WordLanguagePanel isOpen={isWordLanguagePanelOpen} onClose={onWordLanguagePanelClose} />
         )}
       </aside>
     </>

--- a/app/(features)/surah/[surahId]/components/SidebarContent.tsx
+++ b/app/(features)/surah/[surahId]/components/SidebarContent.tsx
@@ -58,7 +58,7 @@ export const SidebarContent = forwardRef<HTMLElement, SidebarContentProps>(
     return (
       <aside
         ref={ref}
-        className={`settings-sidebar fixed lg:static top-16 lg:top-0 bottom-0 right-0 w-[20.7rem] bg-[var(--background)] text-[var(--foreground)] flex-col flex-shrink-0 overflow-y-auto overflow-x-hidden shadow-[-5px_0px_15px_-5px_rgba(0,0,0,0.05)] transition-all duration-300 z-40 lg:z-40 lg:h-full ${
+        className={`settings-sidebar fixed lg:static top-16 lg:top-0 bottom-0 right-0 w-[20.7rem] bg-surface text-primary flex-col flex-shrink-0 overflow-y-auto overflow-x-hidden shadow-[-5px_0px_15px_-5px_rgba(0,0,0,0.05)] transition-all duration-300 z-40 lg:z-40 lg:h-full ${
           isOpen ? 'translate-x-0' : 'translate-x-full'
         } lg:translate-x-0 ${isOpen ? 'flex' : 'hidden'} lg:flex scrollbar-hide`}
         style={{ position: 'relative' }}
@@ -85,7 +85,7 @@ export const SidebarContent = forwardRef<HTMLElement, SidebarContentProps>(
               className={`w-1/2 px-4 py-2 rounded-full text-sm font-semibold transition-colors ${
                 activeTab === 'translation'
                   ? theme === 'light'
-                    ? 'bg-white shadow text-slate-900'
+                    ? 'bg-surface shadow text-slate-900'
                     : 'bg-slate-700 text-white shadow'
                   : theme === 'light'
                     ? 'text-slate-400 hover:text-slate-700'
@@ -99,7 +99,7 @@ export const SidebarContent = forwardRef<HTMLElement, SidebarContentProps>(
               className={`w-1/2 px-4 py-2 rounded-full text-sm font-semibold transition-colors ${
                 activeTab === 'reading'
                   ? theme === 'light'
-                    ? 'bg-white shadow text-slate-900'
+                    ? 'bg-surface shadow text-slate-900'
                     : 'bg-slate-700 text-white shadow'
                   : theme === 'light'
                     ? 'text-slate-400 hover:text-slate-700'
@@ -137,7 +137,7 @@ export const SidebarContent = forwardRef<HTMLElement, SidebarContentProps>(
             </>
           )}
           {activeTab === 'reading' && (
-            <div className="text-center py-8 text-gray-500">
+            <div className="text-center py-8 text-muted">
               Mushaf settings have been moved to the Translation tab.
             </div>
           )}
@@ -152,7 +152,7 @@ export const SidebarContent = forwardRef<HTMLElement, SidebarContentProps>(
               onClick={() => setTheme('light')}
               className={`w-1/2 px-4 py-2 rounded-full text-sm font-semibold transition-colors ${
                 theme === 'light'
-                  ? 'bg-white shadow text-slate-900'
+                  ? 'bg-surface shadow text-slate-900'
                   : 'text-slate-400 hover:text-white'
               }`}
             >

--- a/app/(features)/surah/[surahId]/components/SurahVerseList.tsx
+++ b/app/(features)/surah/[surahId]/components/SurahVerseList.tsx
@@ -42,11 +42,11 @@ export const SurahVerseList = ({
           ))}
           <div ref={loadMoreRef} className="py-4 text-center space-x-2">
             {isValidating && <Spinner className="inline h-5 w-5 text-teal-600" />}
-            {isReachingEnd && <span className="text-gray-500">{t('end_of_surah')}</span>}
+            {isReachingEnd && <span className="text-muted">{t('end_of_surah')}</span>}
           </div>
         </>
       ) : (
-        <div className="text-center py-20 text-gray-500">{t('no_verses_found')}</div>
+        <div className="text-center py-20 text-muted">{t('no_verses_found')}</div>
       )}
     </div>
   );

--- a/app/(features)/surah/[surahId]/components/TafsirSettings.tsx
+++ b/app/(features)/surah/[surahId]/components/TafsirSettings.tsx
@@ -45,7 +45,7 @@ export const TafsirSettings = ({
             />
             <div>
               <div className="flex justify-between mb-1 text-sm">
-                <label className="text-[var(--foreground)]">{t('tafsir_font_size')}</label>
+                <label className="text-primary">{t('tafsir_font_size')}</label>
                 <span className="font-semibold text-teal-700">{settings.tafsirFontSize}</span>
               </div>
               <input

--- a/app/(features)/surah/[surahId]/components/TranslationSettings.tsx
+++ b/app/(features)/surah/[surahId]/components/TranslationSettings.tsx
@@ -44,25 +44,25 @@ export const TranslationSettings = ({
       >
         <div className="space-y-4">
           <div className="flex items-center justify-between pt-2">
-            <span className="text-sm text-[var(--foreground)]">{t('show_word_by_word')}</span>
+            <span className="text-sm text-primary">{t('show_word_by_word')}</span>
             <button
               onClick={() => setSettings({ ...settings, showByWords: !settings.showByWords })}
               className={`relative inline-flex h-6 w-11 items-center rounded-full ${settings.showByWords ? 'bg-teal-600' : 'bg-gray-200'}`}
             >
               <span
-                className={`inline-block h-4 w-4 transform rounded-full bg-white transition ${settings.showByWords ? 'translate-x-6' : 'translate-x-1'}`}
+                className={`inline-block h-4 w-4 transform rounded-full bg-surface transition ${settings.showByWords ? 'translate-x-6' : 'translate-x-1'}`}
               />
             </button>
           </div>
 
           <div className="flex items-center justify-between">
-            <span className="text-sm text-[var(--foreground)]">{t('apply_tajweed')}</span>
+            <span className="text-sm text-primary">{t('apply_tajweed')}</span>
             <button
               onClick={() => setSettings({ ...settings, tajweed: !settings.tajweed })}
               className={`relative inline-flex h-6 w-11 items-center rounded-full ${settings.tajweed ? 'bg-teal-600' : 'bg-gray-200'}`}
             >
               <span
-                className={`inline-block h-4 w-4 transform rounded-full bg-white transition ${settings.tajweed ? 'translate-x-6' : 'translate-x-1'}`}
+                className={`inline-block h-4 w-4 transform rounded-full bg-surface transition ${settings.tajweed ? 'translate-x-6' : 'translate-x-1'}`}
               />
             </button>
           </div>

--- a/app/(features)/surah/[surahId]/components/Verse.tsx
+++ b/app/(features)/surah/[surahId]/components/Verse.tsx
@@ -85,7 +85,7 @@ export const Verse = memo(function Verse({ verse }: VerseProps) {
         {verse.translations?.map((t: Translation) => (
           <div key={t.resource_id}>
             <p
-              className="text-left leading-relaxed text-[var(--foreground)]"
+              className="text-left leading-relaxed text-primary"
               style={{ fontSize: `${settings.translationFontSize}px` }}
               dangerouslySetInnerHTML={{ __html: sanitizeHtml(t.text) }}
             />

--- a/app/(features)/surah/[surahId]/components/WordLanguagePanel.tsx
+++ b/app/(features)/surah/[surahId]/components/WordLanguagePanel.tsx
@@ -25,15 +25,15 @@ const WORD_LANGUAGES = [
   { id: 50, name: 'Tamil', code: 'ta' as LanguageCode },
 ];
 
-export const WordLanguagePanel: React.FC<WordLanguagePanelProps> = ({ 
-  isOpen, 
-  onClose, 
-  renderMode = 'panel' 
+export const WordLanguagePanel: React.FC<WordLanguagePanelProps> = ({
+  isOpen,
+  onClose,
+  renderMode = 'panel',
 }) => {
   const { settings, setSettings } = useSettings();
   const { t } = useTranslation();
   const { theme } = useTheme();
-  
+
   const listContainerRef = useRef<HTMLDivElement>(null);
   const [listHeight, setListHeight] = useState(0);
 
@@ -47,7 +47,7 @@ export const WordLanguagePanel: React.FC<WordLanguagePanelProps> = ({
 
   useEffect(() => {
     if (renderMode === 'content') return; // Skip resize observer for content mode
-    
+
     const element = listContainerRef.current;
     if (!element || !isOpen) return;
 
@@ -101,7 +101,7 @@ export const WordLanguagePanel: React.FC<WordLanguagePanelProps> = ({
                   : 'bg-teal-50 border-teal-200'
                 : theme === 'dark'
                   ? 'bg-slate-800/50 border-slate-700 hover:bg-slate-700/50'
-                  : 'bg-white border-slate-200 hover:bg-slate-50'
+                  : 'bg-surface border-slate-200 hover:bg-slate-50'
             }`}
           >
             <div className="flex-1 min-w-0 pr-3">
@@ -112,7 +112,7 @@ export const WordLanguagePanel: React.FC<WordLanguagePanelProps> = ({
                       ? 'text-teal-200'
                       : 'text-teal-800'
                     : theme === 'dark'
-                      ? 'text-[var(--foreground)]'
+                      ? 'text-primary'
                       : 'text-slate-800'
                 }`}
                 title={language.name}
@@ -135,11 +135,7 @@ export const WordLanguagePanel: React.FC<WordLanguagePanelProps> = ({
 
   // Content mode - render just the list for use inside SettingsSidebar
   if (renderMode === 'content') {
-    return (
-      <div className="flex-grow p-4 space-y-4">
-        {renderLanguageList()}
-      </div>
-    );
+    return <div className="flex-grow p-4 space-y-4">{renderLanguageList()}</div>;
   }
 
   // Panel mode - render as full slide-over panel
@@ -148,7 +144,7 @@ export const WordLanguagePanel: React.FC<WordLanguagePanelProps> = ({
       data-testid="word-language-panel"
       className={`absolute inset-0 flex flex-col transition-transform duration-300 ease-in-out z-50 shadow-lg ${
         isOpen ? 'translate-x-0' : 'translate-x-full'
-      } ${theme === 'dark' ? 'bg-[var(--background)] text-[var(--foreground)]' : 'bg-white text-slate-800'}`}
+      } ${theme === 'dark' ? 'bg-surface text-primary' : 'bg-surface text-slate-800'}`}
     >
       <header
         className={`flex items-center p-4 border-b ${
@@ -163,7 +159,7 @@ export const WordLanguagePanel: React.FC<WordLanguagePanelProps> = ({
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
-            className={`h-6 w-6 ${theme === 'dark' ? 'text-[var(--foreground)]' : 'text-slate-600'}`}
+            className={`h-6 w-6 ${theme === 'dark' ? 'text-primary' : 'text-slate-600'}`}
             fill="none"
             viewBox="0 0 24 24"
             stroke="currentColor"
@@ -174,7 +170,7 @@ export const WordLanguagePanel: React.FC<WordLanguagePanelProps> = ({
         </button>
         <h2
           className={`text-lg font-bold text-center flex-grow ${
-            theme === 'dark' ? 'text-[var(--foreground)]' : 'text-slate-800'
+            theme === 'dark' ? 'text-primary' : 'text-slate-800'
           }`}
         >
           {t('word_by_word_panel_title')}
@@ -183,9 +179,7 @@ export const WordLanguagePanel: React.FC<WordLanguagePanelProps> = ({
 
       <div className="flex-1 flex flex-col min-h-0">
         <div className="flex-1 overflow-y-auto" ref={listContainerRef}>
-          <div className="px-4 pb-4 pt-4">
-            {renderLanguageList()}
-          </div>
+          <div className="px-4 pb-4 pt-4">{renderLanguageList()}</div>
         </div>
       </div>
     </div>

--- a/app/(features)/surah/[surahId]/components/arabic-font-panel/ArabicFontSearch.tsx
+++ b/app/(features)/surah/[surahId]/components/arabic-font-panel/ArabicFontSearch.tsx
@@ -36,7 +36,7 @@ export const ArabicFontSearch: React.FC<ArabicFontSearchProps> = ({
         className={`w-full pl-10 pr-4 py-3 rounded-lg border text-sm placeholder-slate-400 focus:outline-none focus:ring-2 focus:ring-teal-500 transition-colors ${
           theme === 'dark'
             ? 'bg-slate-800 border-slate-700 text-slate-200'
-            : 'bg-white border-slate-200 text-slate-800'
+            : 'bg-surface border-slate-200 text-slate-800'
         }`}
       />
     </div>

--- a/app/(features)/surah/[surahId]/components/arabic-font-panel/ArabicFontSelectionList.tsx
+++ b/app/(features)/surah/[surahId]/components/arabic-font-panel/ArabicFontSelectionList.tsx
@@ -72,7 +72,7 @@ export const ArabicFontSelectionList: React.FC<ArabicFontSelectionListProps> = (
               onDragEnd={handleDragEnd}
               className={`flex items-center justify-between p-3 rounded-lg cursor-grab active:cursor-grabbing transition-all duration-200 ${
                 draggedId === id ? 'opacity-50' : 'opacity-100'
-              } ${theme === 'dark' ? 'bg-slate-700 border border-slate-600 hover:bg-slate-600' : 'bg-white border border-slate-200 hover:bg-slate-50'}`}
+              } ${theme === 'dark' ? 'bg-slate-700 border border-slate-600 hover:bg-slate-600' : 'bg-surface border border-slate-200 hover:bg-slate-50'}`}
             >
               <div className="flex items-center min-w-0">
                 <GripVertical

--- a/app/(features)/surah/[surahId]/components/arabic-font-panel/useArabicFontPanel.ts
+++ b/app/(features)/surah/[surahId]/components/arabic-font-panel/useArabicFontPanel.ts
@@ -20,7 +20,6 @@ export const useArabicFontPanel = (isOpen: boolean) => {
   const [activeFilter, setActiveFilter] = useState('Uthmani');
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
 
-
   // Convert arabicFonts to have consistent interface with other resources
   const fonts: ArabicFont[] = useMemo(() => {
     return arabicFonts.map((font, index) => ({
@@ -89,7 +88,6 @@ export const useArabicFontPanel = (isOpen: boolean) => {
       });
     }
   }, [fonts, settings, setSettings]);
-
 
   return {
     theme,

--- a/app/(features)/surah/[surahId]/components/tafsir-panel/TafsirPanel.tsx
+++ b/app/(features)/surah/[surahId]/components/tafsir-panel/TafsirPanel.tsx
@@ -85,7 +85,7 @@ export const TafsirPanel: React.FC<TafsirPanelProps> = ({ isOpen, onClose }) => 
       data-testid="tafsir-panel"
       className={`absolute inset-0 flex flex-col transition-transform duration-300 ease-in-out z-50 shadow-lg ${
         isOpen ? 'translate-x-0' : 'translate-x-full'
-      } ${theme === 'dark' ? 'bg-[var(--background)] text-[var(--foreground)]' : 'bg-white text-slate-800'}`}
+      } ${theme === 'dark' ? 'bg-surface text-primary' : 'bg-surface text-slate-800'}`}
     >
       <TafsirLimitWarning show={showLimitWarning} theme={theme} />
 
@@ -102,7 +102,7 @@ export const TafsirPanel: React.FC<TafsirPanelProps> = ({ isOpen, onClose }) => 
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
-            className={`h-6 w-6 ${theme === 'dark' ? 'text-[var(--foreground)]' : 'text-slate-600'}`}
+            className={`h-6 w-6 ${theme === 'dark' ? 'text-primary' : 'text-slate-600'}`}
             fill="none"
             viewBox="0 0 24 24"
             stroke="currentColor"
@@ -113,7 +113,7 @@ export const TafsirPanel: React.FC<TafsirPanelProps> = ({ isOpen, onClose }) => 
         </button>
         <h2
           className={`text-lg font-bold text-center flex-grow ${
-            theme === 'dark' ? 'text-[var(--foreground)]' : 'text-slate-800'
+            theme === 'dark' ? 'text-primary' : 'text-slate-800'
           }`}
         >
           Manage Tafsirs
@@ -122,7 +122,7 @@ export const TafsirPanel: React.FC<TafsirPanelProps> = ({ isOpen, onClose }) => 
           onClick={handleReset}
           className={`p-2 rounded-full focus-visible:outline-none transition-colors ${
             theme === 'dark'
-              ? 'text-[var(--foreground)] hover:bg-gray-700'
+              ? 'text-primary hover:bg-gray-700'
               : 'text-slate-500 hover:bg-slate-100 hover:text-slate-700'
           }`}
           title="Reset to Default"
@@ -180,8 +180,8 @@ export const TafsirPanel: React.FC<TafsirPanelProps> = ({ isOpen, onClose }) => 
               <div
                 className={`sticky top-0 z-10 py-2 border-b ${
                   theme === 'dark'
-                    ? 'bg-[var(--background)] border-[var(--border-color)]'
-                    : 'bg-white/95 backdrop-blur-sm border-slate-200'
+                    ? 'bg-surface border-[var(--border-color)]'
+                    : 'bg-surface/95 backdrop-blur-sm border-slate-200'
                 }`}
               >
                 <div className="px-4">
@@ -218,7 +218,7 @@ export const TafsirPanel: React.FC<TafsirPanelProps> = ({ isOpen, onClose }) => 
                         <div key={language}>
                           <h3
                             className={`text-lg font-semibold mb-4 ${
-                              theme === 'dark' ? 'text-[var(--foreground)]' : 'text-slate-800'
+                              theme === 'dark' ? 'text-primary' : 'text-slate-800'
                             }`}
                           >
                             {language}

--- a/app/(features)/surah/[surahId]/components/tafsir-panel/TafsirSearch.tsx
+++ b/app/(features)/surah/[surahId]/components/tafsir-panel/TafsirSearch.tsx
@@ -24,7 +24,7 @@ export const TafsirSearch: React.FC<TafsirSearchProps> = ({ theme, searchTerm, s
       className={`w-full pl-10 pr-4 py-2 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition border ${
         theme === 'dark'
           ? 'bg-slate-800 border-slate-700 text-slate-200'
-          : 'bg-white border-slate-200 text-slate-900'
+          : 'bg-surface border-slate-200 text-slate-900'
       }`}
     />
   </div>

--- a/app/(features)/surah/[surahId]/components/tafsir-panel/TafsirSelectionList.tsx
+++ b/app/(features)/surah/[surahId]/components/tafsir-panel/TafsirSelectionList.tsx
@@ -44,7 +44,7 @@ export const TafsirSelectionList: React.FC<TafsirSelectionListProps> = ({
     </h2>
     <div
       className={`space-y-2 min-h-[40px] rounded-lg p-2 ${
-        theme === 'dark' ? 'bg-slate-800/50 border-slate-700' : 'bg-white border-slate-200'
+        theme === 'dark' ? 'bg-slate-800/50 border-slate-700' : 'bg-surface border-slate-200'
       } border`}
     >
       {orderedSelection.length === 0 ? (
@@ -68,7 +68,9 @@ export const TafsirSelectionList: React.FC<TafsirSelectionListProps> = ({
               className={`flex items-center justify-between p-2 rounded-lg shadow-sm cursor-grab active:cursor-grabbing transition-opacity border ${
                 draggedId === id ? 'opacity-50' : 'opacity-100'
               } ${
-                theme === 'dark' ? 'bg-slate-700/50 border-slate-700' : 'bg-white border-slate-200'
+                theme === 'dark'
+                  ? 'bg-slate-700/50 border-slate-700'
+                  : 'bg-surface border-slate-200'
               }`}
             >
               <div className="flex items-center min-w-0">

--- a/app/(features)/surah/[surahId]/components/translation-panel/TranslationPanel.tsx
+++ b/app/(features)/surah/[surahId]/components/translation-panel/TranslationPanel.tsx
@@ -103,7 +103,7 @@ export const TranslationPanel: React.FC<TranslationPanelProps> = ({ isOpen, onCl
       data-testid="translation-panel"
       className={`absolute inset-0 flex flex-col transition-transform duration-300 ease-in-out z-50 shadow-lg ${
         isOpen ? 'translate-x-0' : 'translate-x-full'
-      } ${theme === 'dark' ? 'bg-[var(--background)] text-[var(--foreground)]' : 'bg-white text-slate-800'}`}
+      } ${theme === 'dark' ? 'bg-surface text-primary' : 'bg-surface text-slate-800'}`}
     >
       <header
         className={`flex items-center p-4 border-b ${
@@ -118,7 +118,7 @@ export const TranslationPanel: React.FC<TranslationPanelProps> = ({ isOpen, onCl
         >
           <svg
             xmlns="http://www.w3.org/2000/svg"
-            className={`h-6 w-6 ${theme === 'dark' ? 'text-[var(--foreground)]' : 'text-slate-600'}`}
+            className={`h-6 w-6 ${theme === 'dark' ? 'text-primary' : 'text-slate-600'}`}
             fill="none"
             viewBox="0 0 24 24"
             stroke="currentColor"
@@ -129,7 +129,7 @@ export const TranslationPanel: React.FC<TranslationPanelProps> = ({ isOpen, onCl
         </button>
         <h2
           className={`text-lg font-bold text-center flex-grow ${
-            theme === 'dark' ? 'text-[var(--foreground)]' : 'text-slate-800'
+            theme === 'dark' ? 'text-primary' : 'text-slate-800'
           }`}
         >
           Manage Translations
@@ -138,7 +138,7 @@ export const TranslationPanel: React.FC<TranslationPanelProps> = ({ isOpen, onCl
           onClick={handleReset}
           className={`p-2 rounded-full focus-visible:outline-none transition-colors ${
             theme === 'dark'
-              ? 'text-[var(--foreground)] hover:bg-gray-700'
+              ? 'text-primary hover:bg-gray-700'
               : 'text-slate-500 hover:bg-slate-100 hover:text-slate-700'
           }`}
           title="Reset to Default"
@@ -200,8 +200,8 @@ export const TranslationPanel: React.FC<TranslationPanelProps> = ({ isOpen, onCl
               <div
                 className={`sticky top-0 z-10 py-2 border-b ${
                   theme === 'dark'
-                    ? 'bg-[var(--background)] border-[var(--border-color)]'
-                    : 'bg-white/95 backdrop-blur-sm border-slate-200'
+                    ? 'bg-surface border-[var(--border-color)]'
+                    : 'bg-surface/95 backdrop-blur-sm border-slate-200'
                 }`}
               >
                 <div className="px-4">

--- a/app/(features)/surah/[surahId]/components/translation-panel/TranslationSelectionList.tsx
+++ b/app/(features)/surah/[surahId]/components/translation-panel/TranslationSelectionList.tsx
@@ -68,7 +68,7 @@ export const TranslationSelectionList: React.FC<TranslationSelectionListProps> =
               onDragEnd={handleDragEnd}
               className={`flex items-center justify-between p-3 rounded-lg cursor-grab active:cursor-grabbing transition-all duration-200 ${
                 draggedId === id ? 'opacity-50' : 'opacity-100'
-              } ${theme === 'dark' ? 'bg-slate-700 border border-slate-600 hover:bg-slate-600' : 'bg-white border border-slate-200 hover:bg-slate-50'}`}
+              } ${theme === 'dark' ? 'bg-slate-700 border border-slate-600 hover:bg-slate-600' : 'bg-surface border border-slate-200 hover:bg-slate-50'}`}
             >
               <div className="flex items-center min-w-0">
                 <GripVertical

--- a/app/(features)/surah/[surahId]/page.tsx
+++ b/app/(features)/surah/[surahId]/page.tsx
@@ -44,8 +44,8 @@ export default function SurahPage({ params }: SurahPageProps) {
   } = useSurahPanels({ translationOptions, wordLanguageOptions, settings });
 
   return (
-    <div className="flex flex-grow bg-white dark:bg-[var(--background)] text-[var(--foreground)] font-sans overflow-hidden">
-      <main className="flex-grow bg-white dark:bg-[var(--background)] p-6 lg:p-10 overflow-y-auto homepage-scrollable-area">
+    <div className="flex flex-grow bg-surface text-primary font-sans overflow-hidden">
+      <main className="flex-grow bg-surface section overflow-y-auto homepage-scrollable-area">
         <SurahVerseList
           verses={verses}
           isLoading={isLoading}

--- a/app/(features)/surah/__tests__/SettingsSidebar.test.tsx
+++ b/app/(features)/surah/__tests__/SettingsSidebar.test.tsx
@@ -73,7 +73,7 @@ describe('SettingsSidebar interactions', () => {
 
     await userEvent.click(screen.getByRole('button', { name: 'IndoPak' }));
     expect(screen.getByText('Noto Nastaliq Urdu')).toBeInTheDocument();
-    
+
     // Close sidebar
     const backButtons = screen.getAllByRole('button', { name: 'Back' });
     await userEvent.click(backButtons[1]);

--- a/app/(features)/tafsir/[surahId]/[ayahId]/components/AyahNavigation.tsx
+++ b/app/(features)/tafsir/[surahId]/[ayahId]/components/AyahNavigation.tsx
@@ -28,7 +28,7 @@ export const AyahNavigation = ({
       onClick={() => navigate(prev)}
       className="flex items-center px-4 py-2 rounded-full bg-teal-600 text-white disabled:opacity-50 font-bold"
     >
-      <div className="flex items-center justify-center w-8 h-8 rounded-full bg-white mr-2">
+      <div className="flex items-center justify-center w-8 h-8 rounded-full bg-surface mr-2">
         <svg
           xmlns="http://www.w3.org/2000/svg"
           className="h-5 w-5 text-teal-600"
@@ -58,7 +58,7 @@ export const AyahNavigation = ({
       onClick={() => navigate(next)}
       className="flex items-center px-4 py-2 rounded-full bg-teal-600 text-white disabled:opacity-50 font-bold"
     >
-      <div className="flex items-center justify-center w-8 h-8 rounded-full bg-white ml-2">
+      <div className="flex items-center justify-center w-8 h-8 rounded-full bg-surface ml-2">
         <svg
           xmlns="http://www.w3.org/2000/svg"
           className="h-5 w-5 text-teal-600"

--- a/app/(features)/tafsir/[surahId]/[ayahId]/components/TafsirPanels.tsx
+++ b/app/(features)/tafsir/[surahId]/[ayahId]/components/TafsirPanels.tsx
@@ -24,24 +24,24 @@ export const TafsirPanels = ({ verseKey, tafsirIds }: TafsirPanelsProps) => {
               onClick={() => togglePanel(id)}
               className="w-full flex items-center justify-between py-3 text-left"
             >
-              <span className="font-semibold text-[var(--foreground)]">Tafsir {id}</span>
+              <span className="font-semibold text-primary">Tafsir {id}</span>
               <ChevronDownIcon
                 size={16}
-                className={`text-gray-500 transition-transform duration-300 ${open ? 'rotate-180' : ''}`}
+                className={`text-muted transition-transform duration-300 ${open ? 'rotate-180' : ''}`}
               />
             </button>
             <div
               className={`grid transition-all duration-300 ease-in-out ${open ? 'grid-rows-[1fr] opacity-100' : 'grid-rows-[0fr] opacity-0'}`}
             >
               <div className="overflow-hidden">
-                <div className="bg-teal-50 dark:bg-slate-800 rounded-md p-4 max-h-64 overflow-y-auto">
+                <div className="bg-teal-50  rounded-md p-4 max-h-64 overflow-y-auto">
                   {loading[id] ? (
                     <div className="flex justify-center py-4">
                       <Spinner className="h-5 w-5 text-teal-600" />
                     </div>
                   ) : (
                     <div
-                      className="prose max-w-none text-[var(--foreground)] whitespace-pre-wrap"
+                      className="prose max-w-none text-primary whitespace-pre-wrap"
                       style={{ fontSize: `${settings.tafsirFontSize}px` }}
                       dangerouslySetInnerHTML={{
                         __html: applyArabicFont(tafsirTexts[id] || '', settings.arabicFontFace),

--- a/app/(features)/tafsir/[surahId]/[ayahId]/components/TafsirTabs.tsx
+++ b/app/(features)/tafsir/[surahId]/[ayahId]/components/TafsirTabs.tsx
@@ -56,14 +56,14 @@ export default function TafsirTabs({ verseKey, tafsirIds }: TafsirTabsProps) {
 
   if (!tabs.length) {
     return (
-      <div className="p-4 text-center text-gray-500">
+      <div className="p-4 text-center text-muted">
         No tafsir resources available. Please check your settings.
       </div>
     );
   }
 
   if (!activeId) {
-    return <div className="p-4 text-center text-gray-500">Loading tafsir...</div>;
+    return <div className="p-4 text-center text-muted">Loading tafsir...</div>;
   }
 
   const activeTab = tabs.find((t) => t.id === activeId);
@@ -80,7 +80,7 @@ export default function TafsirTabs({ verseKey, tafsirIds }: TafsirTabsProps) {
             className={`flex-1 text-center py-3 px-5 rounded-full text-sm font-semibold transition-colors whitespace-nowrap ${
               activeId === t.id
                 ? theme === 'light'
-                  ? 'bg-white shadow text-slate-900'
+                  ? 'bg-surface shadow text-slate-900'
                   : 'bg-slate-700 text-white shadow'
                 : theme === 'light'
                   ? 'text-slate-500 hover:text-slate-800'
@@ -92,9 +92,7 @@ export default function TafsirTabs({ verseKey, tafsirIds }: TafsirTabsProps) {
         ))}
       </div>
       <div className="p-4 mt-4">
-        <h2 className="mb-8 text-center text-xl font-bold text-[var(--foreground)]">
-          {activeTab?.name}
-        </h2>
+        <h2 className="mb-8 text-center text-xl font-bold text-primary">{activeTab?.name}</h2>
         {loading[activeId] ? (
           <div className="flex justify-center py-4">
             <Spinner className="h-5 w-5 text-emerald-600" />

--- a/app/(features)/tafsir/[surahId]/[ayahId]/components/TafsirVerse.tsx
+++ b/app/(features)/tafsir/[surahId]/[ayahId]/components/TafsirVerse.tsx
@@ -45,7 +45,7 @@ export const TafsirVerse = ({ verse, tafsirIds }: TafsirVerseProps) => {
             <div key={t.resource_id}>
                            {' '}
               <p
-                className="text-left leading-relaxed text-[var(--foreground)]"
+                className="text-left leading-relaxed text-primary"
                 style={{ fontSize: `${settings.translationFontSize}px` }}
                 dangerouslySetInnerHTML={{ __html: sanitizeHtml(t.text) }}
               />

--- a/app/(features)/tafsir/[surahId]/[ayahId]/components/TafsirViewer.tsx
+++ b/app/(features)/tafsir/[surahId]/[ayahId]/components/TafsirViewer.tsx
@@ -24,7 +24,7 @@ export const TafsirViewer = ({ verse, tafsirResource, tafsirHtml }: TafsirViewer
       ) : settings.tafsirIds.length === 1 ? (
         <div key={verse.verse_key} className="p-4">
           {tafsirResource && (
-            <h2 className="mb-4 text-center text-xl font-bold text-[var(--foreground)]">
+            <h2 className="mb-4 text-center text-xl font-bold text-primary">
               {tafsirResource.name}
             </h2>
           )}
@@ -35,7 +35,7 @@ export const TafsirViewer = ({ verse, tafsirResource, tafsirHtml }: TafsirViewer
           />
         </div>
       ) : (
-        <div className="p-4 text-center text-gray-500">
+        <div className="p-4 text-center text-muted">
           Please select a tafsir from the settings panel to view commentary.
         </div>
       )}

--- a/app/(features)/tafsir/[surahId]/[ayahId]/components/VerseCard.tsx
+++ b/app/(features)/tafsir/[surahId]/[ayahId]/components/VerseCard.tsx
@@ -67,7 +67,7 @@ export default function VerseCard({ verse }: VerseCardProps) {
   }, [addBookmark, removeBookmark, findBookmark, verse.id]);
 
   return (
-    <div className="relative flex rounded-md border bg-white p-6 shadow">
+    <div className="relative flex rounded-md border bg-surface p-6 shadow">
       <VerseActions
         verseKey={verse.verse_key}
         isPlaying={isPlaying}
@@ -75,7 +75,7 @@ export default function VerseCard({ verse }: VerseCardProps) {
         isBookmarked={isVerseBookmarked}
         onPlayPause={handlePlayPause}
         onBookmark={handleBookmark}
-        className="mr-4 w-14 pt-2 text-gray-500"
+        className="mr-4 w-14 pt-2 text-muted"
       />
            {' '}
       <div className="flex-grow space-y-6">

--- a/app/(features)/tafsir/[surahId]/[ayahId]/components/WordTranslationPanel.tsx
+++ b/app/(features)/tafsir/[surahId]/[ayahId]/components/WordTranslationPanel.tsx
@@ -42,7 +42,7 @@ export const WordTranslationPanel = ({
 
   return (
     <div
-      className={`fixed ${isHidden ? 'top-0' : 'top-16'} bottom-0 right-0 w-[20.7rem] bg-[var(--background)] text-[var(--foreground)] flex flex-col transition-all duration-300 ease-in-out z-50 shadow-lg ${
+      className={`fixed ${isHidden ? 'top-0' : 'top-16'} bottom-0 right-0 w-[20.7rem] bg-surface text-primary flex flex-col transition-all duration-300 ease-in-out z-50 shadow-lg ${
         isOpen ? 'translate-x-0' : 'translate-x-full'
       }`}
     >
@@ -54,15 +54,13 @@ export const WordTranslationPanel = ({
         >
           <ArrowLeftIcon size={18} />
         </button>
-        <h2 className="font-bold text-lg text-[var(--foreground)]">
-          {t('word_by_word_panel_title')}
-        </h2>
+        <h2 className="font-bold text-lg text-primary">{t('word_by_word_panel_title')}</h2>
         <div className="w-8"></div>
       </div>
       <div className="p-3 border-b border-gray-200/80">
         <div className="relative">
           <SearchIcon
-            className="absolute left-3.5 top-1/2 -translate-y-1/2 text-gray-400"
+            className="absolute left-3.5 top-1/2 -translate-y-1/2 text-muted"
             width={18}
             height={18}
           />
@@ -71,7 +69,7 @@ export const WordTranslationPanel = ({
             placeholder={t('search')}
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
-            className="w-full pl-10 pr-3 py-2.5 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-teal-500 outline-none bg-[var(--background)] text-[var(--foreground)]"
+            className="w-full pl-10 pr-3 py-2.5 border border-gray-300 dark:border-gray-600 rounded-lg focus:ring-2 focus:ring-teal-500 outline-none bg-surface text-primary"
           />
         </div>
       </div>
@@ -100,7 +98,7 @@ export const WordTranslationPanel = ({
                 onClose();
               }}
             />
-            <span className="text-sm text-[var(--foreground)]">{lang.name}</span>
+            <span className="text-sm text-primary">{lang.name}</span>
           </label>
         ))}
       </div>

--- a/app/(features)/tafsir/[surahId]/[ayahId]/page.tsx
+++ b/app/(features)/tafsir/[surahId]/[ayahId]/page.tsx
@@ -31,8 +31,8 @@ export default function TafsirVersePage({ params }: TafsirVersePageProps) {
   const [isWordPanelOpen, setIsWordPanelOpen] = useState(false);
 
   return (
-    <div className="flex flex-grow bg-white dark:bg-[var(--background)] text-[var(--foreground)] font-sans overflow-hidden min-h-0">
-      <main className="flex-grow bg-white dark:bg-[var(--background)] overflow-y-auto p-6 lg:p-10 homepage-scrollable-area">
+    <div className="flex flex-grow bg-surface text-primary font-sans overflow-hidden min-h-0">
+      <main className="flex-grow bg-surface section overflow-y-auto homepage-scrollable-area">
         <div className="w-full space-y-6">
           <AyahNavigation
             prev={prev}

--- a/app/globals.css
+++ b/app/globals.css
@@ -29,6 +29,16 @@
   }
 }
 
+@layer components {
+  .section {
+    @apply p-6 lg:p-10;
+  }
+
+  .card {
+    @apply rounded-lg bg-surface p-4 shadow-sm;
+  }
+}
+
 /* ===== Custom Range Slider Styles ===== */
 input[type='range'] {
   -webkit-appearance: none;

--- a/app/providers/BookmarkContext.tsx
+++ b/app/providers/BookmarkContext.tsx
@@ -1,14 +1,7 @@
 'use client';
 
 import { Folder, Bookmark } from '@/types';
-import {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react';
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
 
 const BOOKMARKS_STORAGE_KEY = 'quranAppBookmarks_v2'; // Use a new key for the new structure
 const OLD_BOOKMARKS_STORAGE_KEY = 'quranAppBookmarks'; // Old key for migration
@@ -44,12 +37,12 @@ export const BookmarkProvider = ({ children }: { children: React.ReactNode }) =>
         if (oldBookmarks) {
           try {
             const verseIds: string[] = JSON.parse(oldBookmarks);
-            if (Array.isArray(verseIds) && verseIds.every(id => typeof id === 'string')) {
+            if (Array.isArray(verseIds) && verseIds.every((id) => typeof id === 'string')) {
               const migratedFolder: Folder = {
                 id: `migrated-${Date.now()}`,
                 name: 'Uncategorized',
                 createdAt: Date.now(),
-                bookmarks: verseIds.map(verseId => ({
+                bookmarks: verseIds.map((verseId) => ({
                   verseId,
                   createdAt: Date.now(),
                 })),
@@ -92,9 +85,7 @@ export const BookmarkProvider = ({ children }: { children: React.ReactNode }) =>
 
   const renameFolder = useCallback((folderId: string, newName: string) => {
     setFolders((prev) =>
-      prev.map((folder) =>
-        folder.id === folderId ? { ...folder, name: newName } : folder
-      )
+      prev.map((folder) => (folder.id === folderId ? { ...folder, name: newName } : folder))
     );
   }, []);
 
@@ -121,7 +112,7 @@ export const BookmarkProvider = ({ children }: { children: React.ReactNode }) =>
       return prev.map((folder) => {
         if (folder.id === targetFolderId) {
           // Avoid adding duplicate bookmarks
-          if (folder.bookmarks.some(b => b.verseId === verseId)) {
+          if (folder.bookmarks.some((b) => b.verseId === verseId)) {
             return folder;
           }
           const newBookmark: Bookmark = { verseId, createdAt: Date.now() };
@@ -146,19 +137,25 @@ export const BookmarkProvider = ({ children }: { children: React.ReactNode }) =>
     );
   }, []);
 
-  const isBookmarked = useCallback((verseId: string) => {
-    return folders.some(folder => folder.bookmarks.some(b => b.verseId === verseId));
-  }, [folders]);
+  const isBookmarked = useCallback(
+    (verseId: string) => {
+      return folders.some((folder) => folder.bookmarks.some((b) => b.verseId === verseId));
+    },
+    [folders]
+  );
 
-  const findBookmark = useCallback((verseId: string): { folder: Folder; bookmark: Bookmark } | null => {
-    for (const folder of folders) {
-      const bookmark = folder.bookmarks.find(b => b.verseId === verseId);
-      if (bookmark) {
-        return { folder, bookmark };
+  const findBookmark = useCallback(
+    (verseId: string): { folder: Folder; bookmark: Bookmark } | null => {
+      for (const folder of folders) {
+        const bookmark = folder.bookmarks.find((b) => b.verseId === verseId);
+        if (bookmark) {
+          return { folder, bookmark };
+        }
       }
-    }
-    return null;
-  }, [folders]);
+      return null;
+    },
+    [folders]
+  );
 
   const value = useMemo(
     () => ({
@@ -171,7 +168,16 @@ export const BookmarkProvider = ({ children }: { children: React.ReactNode }) =>
       isBookmarked,
       findBookmark,
     }),
-    [folders, createFolder, deleteFolder, renameFolder, addBookmark, removeBookmark, isBookmarked, findBookmark]
+    [
+      folders,
+      createFolder,
+      deleteFolder,
+      renameFolder,
+      addBookmark,
+      removeBookmark,
+      isBookmarked,
+      findBookmark,
+    ]
   );
 
   return <BookmarkContext.Provider value={value}>{children}</BookmarkContext.Provider>;

--- a/app/providers/__tests__/BookmarkContext.test.tsx
+++ b/app/providers/__tests__/BookmarkContext.test.tsx
@@ -143,7 +143,7 @@ describe('BookmarkContext with Folders', () => {
       expect(folders).toHaveLength(1);
       expect(folders[0].name).toBe('Uncategorized');
       expect(folders[0].bookmarks).toHaveLength(2);
-      expect(folders[0].bookmarks.map(b => b.verseId)).toEqual(['1:1', '1:2']);
+      expect(folders[0].bookmarks.map((b) => b.verseId)).toEqual(['1:1', '1:2']);
 
       // Check that the old key has been removed
       expect(localStorage.getItem(OLD_BOOKMARKS_STORAGE_KEY)).toBeNull();

--- a/app/theme.css
+++ b/app/theme.css
@@ -1,6 +1,7 @@
 :root {
   --color-surface: 247 249 249;
   --color-text: 55 65 81;
+  --color-text-muted: 107 114 128;
   --color-accent: 13 148 136;
   --color-accent-hover: 15 118 110;
   --color-border: 229 231 235;
@@ -16,6 +17,7 @@
 .dark {
   --color-surface: 26 32 44;
   --color-text: 209 213 219;
+  --color-text-muted: 156 163 175;
   --color-accent: 13 148 136;
   --color-accent-hover: 15 118 110;
   --color-border: 75 85 99;

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -7,6 +7,9 @@ const config = {
   theme: {
     extend: {
       colors: {
+        surface: 'rgb(var(--color-surface) / <alpha-value>)',
+        primary: 'rgb(var(--color-text) / <alpha-value>)',
+        muted: 'rgb(var(--color-text-muted) / <alpha-value>)',
         background: 'rgb(var(--color-surface) / <alpha-value>)',
         foreground: 'rgb(var(--color-text) / <alpha-value>)',
         border: 'rgb(var(--color-border) / <alpha-value>)',


### PR DESCRIPTION
## Summary
- add surface/primary/muted color tokens and reusable section and card utilities
- refactor feature pages to use text-primary and bg-surface
- document token usage and utilities in AGENTS.md

## Testing
- `npm run lint` *(fails: warnings for unused vars)*
- `npm run check` *(fails: type errors in bookmark context and missing modules)*

------
https://chatgpt.com/codex/tasks/task_b_68a26225013c832fb754bdb6975154e8