### PR TITLE
chore: ignore mcp-server

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -19,6 +19,9 @@ const tokenRules = {
 };
 
 const eslintConfig = [
+  {
+    ignores: ['mcp-server'],
+  },
   ...compat.extends(
     'next/core-web-vitals',
     'next/typescript',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,5 +25,5 @@
     }
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "mcp-server"]
 }


### PR DESCRIPTION
## Summary
- exclude mcp-server from TypeScript compilation
- ignore mcp-server in ESLint config

## Testing
- `npm run lint`
- `npm run check` *(fails: Code style issues found in 13 files)*
- `npm run type-check`
- `npm run test:ci` *(fails: 3 failing test suites)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68a480cadcb0832fa9d9c80b622285aa