### PR TITLE
refactor: use tokens in home components

### DIFF
--- a/app/(features)/home/components/HomeHeader.tsx
+++ b/app/(features)/home/components/HomeHeader.tsx
@@ -1,31 +1,12 @@
 'use client';
-import { useTheme } from '@/app/providers/ThemeContext';
-import { SunIcon, MoonIcon } from '@/app/shared/icons';
+import { ThemeToggle } from '@/app/shared/ui';
 
 export default function HomeHeader() {
-  const { theme, setTheme } = useTheme();
-
   return (
     <header className="w-full py-4">
-      <nav
-        className={`flex justify-between items-center max-w-screen-2xl mx-auto p-3 sm:p-4 rounded-2xl backdrop-blur-xl shadow-lg hover:shadow-xl transition-all duration-300 ${theme === 'light' ? 'bg-surface/60' : 'bg-slate-800/50'}`}
-      >
-        <h1
-          className={`text-2xl font-bold tracking-wider ${theme === 'light' ? 'text-slate-900' : 'text-white'}`}
-        >
-          Al Qur&apos;an
-        </h1>
-        <button
-          onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
-          className="p-2 bg-surface/40 dark:bg-surface/10 rounded-full hover:bg-surface/60 dark:hover:bg-surface/20 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-teal-500"
-          aria-label="Toggle Theme"
-        >
-          {theme === 'light' ? (
-            <MoonIcon className="w-5 h-5 text-slate-700" />
-          ) : (
-            <SunIcon className="w-5 h-5 text-yellow-400" />
-          )}
-        </button>
+      <nav className="flex justify-between items-center max-w-screen-2xl mx-auto p-3 sm:p-4 rounded-2xl backdrop-blur-xl shadow-lg hover:shadow-xl transition-all duration-300 bg-surface/60">
+        <h1 className="text-2xl font-bold tracking-wider text-primary">Al Qur&apos;an</h1>
+        <ThemeToggle />
       </nav>
     </header>
   );

--- a/app/(features)/home/components/HomePage.tsx
+++ b/app/(features)/home/components/HomePage.tsx
@@ -1,6 +1,5 @@
 'use client';
 import React, { useState } from 'react';
-import { useTheme } from '@/app/providers/ThemeContext';
 import VerseOfDay from './VerseOfDay';
 import HomePageBackground from './HomePageBackground';
 import HomeHeader from './HomeHeader';
@@ -14,20 +13,15 @@ import HomeTabs from './HomeTabs';
  * Features:
  * - Search bar for filtering Surahs, Juz, and pages.
  * - Tab navigation to switch between Surah, Juz, and Page views.
- * - Theme toggle to switch between light and dark modes.
  *
  * Internal state:
  * - `searchQuery` stores the user's search input.
- * - `theme` is managed via `useTheme`.
  */
 export default function HomePage() {
   const [searchQuery, setSearchQuery] = useState('');
-  const { theme } = useTheme();
 
   return (
-    <div
-      className={`relative h-screen flex flex-col ${theme === 'light' ? 'bg-surface text-slate-900' : 'bg-transparent '} overflow-hidden`}
-    >
+    <div className="relative h-screen flex flex-col overflow-hidden bg-background text-foreground">
       <HomePageBackground />
 
       <div className="relative z-10 flex flex-col h-full overflow-y-auto px-4 sm:px-6 lg:px-8 homepage-scrollable-area">
@@ -35,14 +29,10 @@ export default function HomePage() {
 
         <main className="flex-grow flex flex-col items-center justify-center text-center pt-20 pb-10">
           <div className="content-visibility-auto animate-fade-in-up">
-            <h2
-              className={`text-5xl md:text-7xl font-bold tracking-tight ${theme === 'light' ? 'text-slate-800' : 'bg-clip-text text-transparent bg-gradient-to-b from-white to-slate-400'}`}
-            >
+            <h2 className="text-5xl md:text-7xl font-bold tracking-tight text-foreground">
               The Noble Qur&apos;an
             </h2>
-            <p
-              className={`mt-4 text-lg md:text-xl max-w-2xl mx-auto ${theme === 'light' ? 'text-slate-600' : 'text-slate-400'}`}
-            >
+            <p className="mt-4 text-lg md:text-xl max-w-2xl mx-auto text-muted">
               Read! In the name of your Lord
             </p>
           </div>

--- a/app/(features)/home/components/HomeSearch.tsx
+++ b/app/(features)/home/components/HomeSearch.tsx
@@ -1,6 +1,5 @@
 'use client';
 import { SearchSolidIcon } from '@/app/shared/icons';
-import { useTheme } from '@/app/providers/ThemeContext';
 
 interface HomeSearchProps {
   searchQuery: string;
@@ -8,13 +7,7 @@ interface HomeSearchProps {
 }
 
 export default function HomeSearch({ searchQuery, setSearchQuery }: HomeSearchProps) {
-  const { theme } = useTheme();
   const shortcutSurahs = ['Al-Mulk', 'Al-Kahf', 'Ya-Sin', 'Al-Ikhlas'];
-
-  const searchBarClasses =
-    theme === 'light'
-      ? 'bg-surface text-primary border-none placeholder-gray-400'
-      : 'bg-gray-800 text-muted border-none placeholder-gray-400';
 
   return (
     <>
@@ -29,7 +22,7 @@ export default function HomeSearch({ searchQuery, setSearchQuery }: HomeSearchPr
             placeholder="What do you want to read?"
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            className={`w-full pl-12 pr-4 py-3 rounded-lg ring-0 focus:outline-none focus:ring-0 transition-all duration-300 hover:shadow-lg text-lg ${searchBarClasses} backdrop-blur-xl shadow-lg hover:shadow-xl ${theme === 'light' ? 'bg-surface/60' : 'bg-slate-800/50'} animate-fade-in-up animation-delay-200`}
+            className="w-full pl-12 pr-4 py-3 rounded-lg ring-0 focus:outline-none focus:ring-0 transition-all duration-300 hover:shadow-lg text-lg bg-surface/60 text-foreground placeholder-muted backdrop-blur-xl shadow-lg hover:shadow-xl animate-fade-in-up animation-delay-200"
           />
         </div>
       </div>
@@ -38,11 +31,7 @@ export default function HomeSearch({ searchQuery, setSearchQuery }: HomeSearchPr
         {shortcutSurahs.map((name) => (
           <button
             key={name}
-            className={`px-4 sm:px-5 py-2 rounded-full font-medium shadow-sm transition-all duration-200 ${
-              theme === 'light'
-                ? 'bg-surface border border-gray-200 text-slate-800 hover:bg-gray-100 hover:shadow-md'
-                : 'bg-slate-800/40 border-slate-700/50 text-slate-300 backdrop-blur-md hover:bg-slate-700/60 hover:scale-105 transform hover:shadow-md'
-            }`}
+            className="px-4 sm:px-5 py-2 rounded-full font-medium shadow-sm transition-all duration-200 bg-surface border border-border text-foreground hover:bg-interactive-hover hover:shadow-md transform hover:scale-105 backdrop-blur-md"
           >
             {name}
           </button>

--- a/app/(features)/home/components/HomeTabs.tsx
+++ b/app/(features)/home/components/HomeTabs.tsx
@@ -1,6 +1,5 @@
 'use client';
 import React, { useState } from 'react';
-import { useTheme } from '@/app/providers/ThemeContext';
 import SurahTab from './SurahTab';
 import JuzTab from './JuzTab';
 import PageTab from './PageTab';
@@ -11,25 +10,18 @@ interface HomeTabsProps {
 
 export default function HomeTabs({ searchQuery }: HomeTabsProps) {
   const [activeTab, setActiveTab] = useState<'Surah' | 'Juz' | 'Page'>('Surah');
-  const { theme } = useTheme();
 
   return (
     <section id="surahs" className="py-20 max-w-screen-2xl mx-auto w-full">
       <div className="flex justify-between items-center mb-8 content-visibility-auto animate-fade-in-up animation-delay-600">
-        <h2 className="text-3xl font-bold text-slate-900 dark:text-white">All Surahs</h2>
-        <div
-          className={`flex items-center p-1 sm:p-2 rounded-full ${theme === 'light' ? 'bg-gray-100' : 'bg-slate-800/60'}`}
-        >
+        <h2 className="text-3xl font-bold text-foreground">All Surahs</h2>
+        <div className="flex items-center p-1 sm:p-2 rounded-full bg-interactive">
           <button
             onClick={() => setActiveTab('Surah')}
             className={`px-4 sm:px-5 py-2 rounded-full text-sm font-semibold transition-colors ${
               activeTab === 'Surah'
-                ? theme === 'light'
-                  ? 'bg-surface shadow text-slate-900'
-                  : 'bg-slate-700 text-white shadow'
-                : theme === 'light'
-                  ? 'text-slate-500 hover:text-slate-800'
-                  : 'text-slate-400 hover:text-white'
+                ? 'bg-surface shadow text-foreground'
+                : 'text-muted hover:text-foreground'
             }`}
           >
             Surah
@@ -38,12 +30,8 @@ export default function HomeTabs({ searchQuery }: HomeTabsProps) {
             onClick={() => setActiveTab('Juz')}
             className={`px-4 sm:px-5 py-2 rounded-full text-sm font-semibold transition-colors ${
               activeTab === 'Juz'
-                ? theme === 'light'
-                  ? 'bg-surface shadow text-slate-900'
-                  : 'bg-slate-700 text-white shadow'
-                : theme === 'light'
-                  ? 'text-slate-500 hover:text-slate-800'
-                  : 'text-slate-400 hover:text-white'
+                ? 'bg-surface shadow text-foreground'
+                : 'text-muted hover:text-foreground'
             }`}
           >
             Juz
@@ -52,12 +40,8 @@ export default function HomeTabs({ searchQuery }: HomeTabsProps) {
             onClick={() => setActiveTab('Page')}
             className={`px-4 sm:px-5 py-2 rounded-full text-sm font-semibold transition-colors ${
               activeTab === 'Page'
-                ? theme === 'light'
-                  ? 'bg-surface shadow text-slate-900'
-                  : 'bg-slate-700 text-white shadow'
-                : theme === 'light'
-                  ? 'text-slate-500 hover:text-slate-800'
-                  : 'text-slate-400 hover:text-white'
+                ? 'bg-surface shadow text-foreground'
+                : 'text-muted hover:text-foreground'
             }`}
           >
             Page

--- a/app/(features)/home/components/SurahCard.tsx
+++ b/app/(features)/home/components/SurahCard.tsx
@@ -1,5 +1,4 @@
 import Link from 'next/link';
-import { useTheme } from '@/app/providers/ThemeContext';
 import type { Surah } from '@/types';
 
 export interface SurahCardProps {
@@ -7,8 +6,6 @@ export interface SurahCardProps {
 }
 
 export function SurahCard({ surah }: SurahCardProps) {
-  const { theme } = useTheme();
-
   return (
     <Link
       href={`/surah/${surah.number}`}
@@ -24,26 +21,18 @@ export function SurahCard({ surah }: SurahCardProps) {
             {surah.number}
           </div>
           <div>
-            <h3
-              className={`font-semibold text-lg ${theme === 'light' ? 'text-slate-900' : 'text-white'}`}
-            >
-              {surah.name}
-            </h3>
-            <p className={`text-sm ${theme === 'light' ? 'text-slate-600' : 'text-slate-400'}`}>
-              {surah.meaning}
-            </p>
+            <h3 className="font-semibold text-lg text-foreground">{surah.name}</h3>
+            <p className="text-sm text-muted">{surah.meaning}</p>
           </div>
         </div>
         <div className="text-right">
           <p
-            className={`font-amiri text-2xl ${theme === 'light' ? 'text-slate-800 group-hover:text-accent' : 'text-slate-300 group-hover:text-accent'} transition-colors`}
+            className="font-amiri text-2xl text-foreground group-hover:text-accent transition-colors"
             lang="ar"
           >
             {surah.arabicName}
           </p>
-          <p className={`text-sm ${theme === 'light' ? 'text-slate-600' : 'text-slate-400'}`}>
-            {surah.verses} Verses
-          </p>
+          <p className="text-sm text-muted">{surah.verses} Verses</p>
         </div>
       </article>
     </Link>


### PR DESCRIPTION
## Summary
- replace theme conditionals in home components with semantic tokens
- remove `useTheme` usage and wire up shared `ThemeToggle`

## Testing
- `npx prettier app/(features)/home/components/HomeHeader.tsx app/(features)/home/components/HomePage.tsx app/(features)/home/components/HomeSearch.tsx app/(features)/home/components/HomeTabs.tsx app/(features)/home/components/SurahCard.tsx -w`
- `npm run lint` *(fails: Unexpected any in tafsir translation files)*
- `npm run check` *(fails: SyntaxError in templates/Component.template.tsx)*

------
https://chatgpt.com/codex/tasks/task_b_68a4d059a334832fae935238d60f32a0