### PR TITLE
refactor: type tafsir and translation panels

### DIFF
--- a/app/(features)/surah/[surahId]/components/tafsir-panel/components/TafsirPanelContent.tsx
+++ b/app/(features)/surah/[surahId]/components/tafsir-panel/components/TafsirPanelContent.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import { AlertCircle } from 'lucide-react';
 import { ResourceTabs, ResourceList } from '@/app/shared/resource-panel';
+import { TafsirResource } from '@/types';
 import { TafsirSearch } from '../TafsirSearch';
 import { TafsirSelectionList } from '../TafsirSelectionList';
 import { TafsirLimitWarning } from '../TafsirLimitWarning';
@@ -13,8 +14,8 @@ interface TafsirPanelContentProps {
   showLimitWarning: boolean;
   searchTerm: string;
   setSearchTerm: (term: string) => void;
-  orderedSelection: any[];
-  tafsirs: any[];
+  orderedSelection: number[];
+  tafsirs: TafsirResource[];
   handleSelectionToggle: (id: number) => void;
   handleDragStart: (id: number) => void;
   handleDragOver: (event: React.DragEvent) => void;
@@ -29,7 +30,7 @@ interface TafsirPanelContentProps {
   canScrollRight: boolean;
   scrollTabsLeft: () => void;
   scrollTabsRight: () => void;
-  resourcesToRender: any[];
+  resourcesToRender: TafsirResource[];
   selectedIds: Set<number>;
   listHeight: number;
   listContainerRef: React.RefObject<HTMLDivElement>;

--- a/app/(features)/surah/[surahId]/components/tafsir-panel/hooks/useTafsirSections.ts
+++ b/app/(features)/surah/[surahId]/components/tafsir-panel/hooks/useTafsirSections.ts
@@ -1,7 +1,9 @@
+import { TafsirResource } from '@/types';
+
 export const useTafsirSections = (
   activeFilter: string,
-  tafsirs: any[],
-  groupedTafsirs: Record<string, any[]>
+  tafsirs: TafsirResource[],
+  groupedTafsirs: Record<string, TafsirResource[]>
 ) => {
   const resourcesToRender = activeFilter === 'All' ? tafsirs : groupedTafsirs[activeFilter] || [];
 

--- a/app/(features)/surah/[surahId]/components/tafsir-panel/tafsirPanel.utils.ts
+++ b/app/(features)/surah/[surahId]/components/tafsir-panel/tafsirPanel.utils.ts
@@ -1,7 +1,6 @@
-export interface Tafsir {
-  id: number;
-  name: string;
-  lang: string;
+import { TafsirResource } from '@/types';
+
+export interface Tafsir extends TafsirResource {
   selected: boolean;
 }
 

--- a/app/(features)/surah/[surahId]/components/tafsir-panel/useTafsirPanel.ts
+++ b/app/(features)/surah/[surahId]/components/tafsir-panel/useTafsirPanel.ts
@@ -37,7 +37,7 @@ export const useTafsirPanel = (isOpen: boolean) => {
       const formatted: Tafsir[] = data.map((t) => ({
         id: t.id,
         name: t.name,
-        lang: capitalizeLanguageName(t.language_name),
+        lang: capitalizeLanguageName(t.lang),
         selected: false,
       }));
       setTafsirs(formatted);

--- a/app/(features)/surah/[surahId]/components/translation-panel/TranslationSelectionList.tsx
+++ b/app/(features)/surah/[surahId]/components/translation-panel/TranslationSelectionList.tsx
@@ -3,11 +3,11 @@
 import React from 'react';
 import { GripVertical, X } from 'lucide-react';
 import { MAX_SELECTIONS } from './useTranslationPanel';
-import { Translation } from './translationPanel.types';
+import { TranslationResource } from '@/types';
 
 interface TranslationSelectionListProps {
   orderedSelection: number[];
-  translations: Translation[];
+  translations: TranslationResource[];
   handleSelectionToggle: (id: number) => void;
   handleDragStart: (e: React.DragEvent<HTMLDivElement>, id: number) => void;
   handleDragOver: (e: React.DragEvent<HTMLDivElement>) => void;

--- a/app/(features)/surah/[surahId]/components/translation-panel/components/TranslationPanelContent.tsx
+++ b/app/(features)/surah/[surahId]/components/translation-panel/components/TranslationPanelContent.tsx
@@ -3,6 +3,7 @@
 import React from 'react';
 import { AlertCircle } from 'lucide-react';
 import { ResourceTabs, ResourceList, ResourceItem } from '@/app/shared/resource-panel';
+import { TranslationResource } from '@/types';
 import { TranslationSearch } from '../TranslationSearch';
 import { TranslationSelectionList } from '../TranslationSelectionList';
 
@@ -11,8 +12,8 @@ interface TranslationPanelContentProps {
   error: string | null;
   searchTerm: string;
   setSearchTerm: (term: string) => void;
-  orderedSelection: any[];
-  translations: any[];
+  orderedSelection: number[];
+  translations: TranslationResource[];
   handleSelectionToggle: (id: number) => void;
   handleDragStart: (id: number) => void;
   handleDragOver: (event: React.DragEvent) => void;
@@ -27,8 +28,8 @@ interface TranslationPanelContentProps {
   canScrollRight: boolean;
   scrollTabsLeft: () => void;
   scrollTabsRight: () => void;
-  sectionsToRender: Array<{ language: string; items: any[] }>;
-  resourcesToRender: any[];
+  sectionsToRender: Array<{ language: string; items: TranslationResource[] }>;
+  resourcesToRender: TranslationResource[];
   selectedIds: Set<number>;
   listHeight: number;
   listContainerRef: React.RefObject<HTMLDivElement>;

--- a/app/(features)/surah/[surahId]/components/translation-panel/hooks/useTranslationSections.ts
+++ b/app/(features)/surah/[surahId]/components/translation-panel/hooks/useTranslationSections.ts
@@ -1,7 +1,9 @@
+import { TranslationResource } from '@/types';
+
 export const useTranslationSections = (
   activeFilter: string,
-  translations: any[],
-  groupedTranslations: Record<string, any[]>
+  translations: TranslationResource[],
+  groupedTranslations: Record<string, TranslationResource[]>
 ) => {
   const resourcesToRender =
     activeFilter === 'All' ? translations : groupedTranslations[activeFilter] || [];

--- a/app/(features)/surah/[surahId]/components/translation-panel/translationPanel.data.ts
+++ b/app/(features)/surah/[surahId]/components/translation-panel/translationPanel.data.ts
@@ -1,6 +1,6 @@
-import { Translation } from './translationPanel.types';
+import { TranslationResource } from '@/types';
 
-export const initialTranslationsData: Translation[] = [
+export const initialTranslationsData: TranslationResource[] = [
   { id: 1, name: 'M.A.S. Abdel Haleem', lang: 'English' },
   { id: 2, name: "Fadel Soliman, Bridges' translation", lang: 'English' },
   { id: 3, name: 'T. Usmani', lang: 'English' },

--- a/app/(features)/surah/[surahId]/components/translation-panel/translationPanel.types.ts
+++ b/app/(features)/surah/[surahId]/components/translation-panel/translationPanel.types.ts
@@ -1,5 +1,0 @@
-export interface Translation {
-  id: number;
-  name: string;
-  lang: string;
-}

--- a/app/(features)/surah/[surahId]/components/translation-panel/useTranslationPanel.ts
+++ b/app/(features)/surah/[surahId]/components/translation-panel/useTranslationPanel.ts
@@ -14,14 +14,13 @@ import {
   updateScrollState,
 } from './translationPanel.utils';
 import { initialTranslationsData } from './translationPanel.data';
-import { Translation } from './translationPanel.types';
 
 export const MAX_SELECTIONS = 5;
 
 export const useTranslationPanel = (isOpen: boolean) => {
   const { theme } = useTheme();
   const { settings, setTranslationIds } = useSettings();
-  const [translations, setTranslations] = useState<Translation[]>([]);
+  const [translations, setTranslations] = useState<TranslationResource[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -35,10 +34,9 @@ export const useTranslationPanel = (isOpen: boolean) => {
         setLoading(true);
         setError(null);
         const apiTranslations = await getTranslations();
-        const formatted: Translation[] = apiTranslations.map((t: TranslationResource) => ({
-          id: t.id,
-          name: t.name,
-          lang: capitalizeLanguageName(t.language_name),
+        const formatted = apiTranslations.map((t) => ({
+          ...t,
+          lang: capitalizeLanguageName(t.lang),
         }));
         setTranslations(formatted);
       } catch (error) {
@@ -65,7 +63,7 @@ export const useTranslationPanel = (isOpen: boolean) => {
     return a.localeCompare(b);
   };
 
-  const selectable = useSelectableResources<Translation>({
+  const selectable = useSelectableResources<TranslationResource>({
     resources: translations,
     selectionLimit: MAX_SELECTIONS,
     languageSort,

--- a/app/(features)/surah/hooks/useTranslationOptions.ts
+++ b/app/(features)/surah/hooks/useTranslationOptions.ts
@@ -20,7 +20,7 @@ export function useTranslationOptions() {
   const wordLanguageMap = useMemo(() => {
     const map: Record<string, number> = {};
     (wordTranslationOptionsData || []).forEach((o) => {
-      const name = o.language_name.toLowerCase();
+      const name = o.lang.toLowerCase();
       if (!map[name]) {
         map[name] = o.id;
       }

--- a/app/(features)/tafsir/__tests__/TafsirVersePage.test.tsx
+++ b/app/(features)/tafsir/__tests__/TafsirVersePage.test.tsx
@@ -78,8 +78,8 @@ const verse: Verse = {
 };
 
 const resources = [
-  { id: 1, name: 'Tafsir One', language_name: 'english' },
-  { id: 2, name: 'Tafsir Two', language_name: 'english' },
+  { id: 1, name: 'Tafsir One', lang: 'english' },
+  { id: 2, name: 'Tafsir Two', lang: 'english' },
 ];
 
 beforeEach(() => {

--- a/app/(features)/tafsir/hooks/useWordTranslations.ts
+++ b/app/(features)/tafsir/hooks/useWordTranslations.ts
@@ -18,7 +18,7 @@ export const useWordTranslations = () => {
   const wordLanguageMap = useMemo(() => {
     const map: Record<string, number> = {};
     (data || []).forEach((o) => {
-      const name = o.language_name.toLowerCase();
+      const name = o.lang.toLowerCase();
       if (!map[name]) {
         map[name] = o.id;
       }

--- a/lib/api/__tests__/tafsir.test.ts
+++ b/lib/api/__tests__/tafsir.test.ts
@@ -1,5 +1,6 @@
-import { getTafsirByVerse, getTafsirResources, TafsirResource } from '@/lib/api/tafsir';
+import { getTafsirByVerse, getTafsirResources } from '@/lib/api/tafsir';
 import { API_BASE_URL } from '@/lib/api';
+import { TafsirResource } from '@/types';
 
 describe('getTafsirResources', () => {
   afterEach(() => {
@@ -7,7 +8,7 @@ describe('getTafsirResources', () => {
   });
 
   it('parses tafsir resources', async () => {
-    const mockResource: TafsirResource = {
+    const apiResource = {
       id: 1,
       slug: 'test',
       name: 'Test Tafsir',
@@ -16,12 +17,13 @@ describe('getTafsirResources', () => {
 
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
-      json: () => Promise.resolve({ tafsirs: [mockResource] }),
+      json: () => Promise.resolve({ tafsirs: [apiResource] }),
     }) as jest.Mock;
 
     const result = await getTafsirResources();
     expect(global.fetch).toHaveBeenCalledWith(`${API_BASE_URL}/resources/tafsirs`);
-    expect(result).toEqual([mockResource]);
+    const expected: TafsirResource[] = [{ id: 1, name: 'Test Tafsir', lang: 'English' }];
+    expect(result).toEqual(expected);
   });
 
   it('throws on fetch error', async () => {

--- a/lib/api/__tests__/translations.test.ts
+++ b/lib/api/__tests__/translations.test.ts
@@ -8,18 +8,17 @@ describe('getTranslations', () => {
   });
 
   it('fetches translations', async () => {
-    const mockTranslations: TranslationResource[] = [
-      { id: 1, name: 'Saheeh', language_name: 'English' },
-    ];
+    const apiResponse = [{ id: 1, name: 'Saheeh', language_name: 'English' }];
 
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
-      json: () => Promise.resolve({ translations: mockTranslations }),
+      json: () => Promise.resolve({ translations: apiResponse }),
     }) as jest.Mock;
 
     const result = await getTranslations();
     expect(global.fetch).toHaveBeenCalledWith(`${API_BASE_URL}/resources/translations`);
-    expect(result).toEqual(mockTranslations);
+    const expected: TranslationResource[] = [{ id: 1, name: 'Saheeh', lang: 'English' }];
+    expect(result).toEqual(expected);
   });
 
   it('throws on fetch error', async () => {
@@ -34,20 +33,19 @@ describe('getWordTranslations', () => {
   });
 
   it('fetches word-by-word translations', async () => {
-    const mockTranslations: TranslationResource[] = [
-      { id: 1, name: 'WBW', language_name: 'English' },
-    ];
+    const apiResponse = [{ id: 1, name: 'WBW', language_name: 'English' }];
 
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
-      json: () => Promise.resolve({ translations: mockTranslations }),
+      json: () => Promise.resolve({ translations: apiResponse }),
     }) as jest.Mock;
 
     const result = await getWordTranslations();
     expect(global.fetch).toHaveBeenCalledWith(
       `${API_BASE_URL}/resources/translations?resource_type=word_by_word`
     );
-    expect(result).toEqual(mockTranslations);
+    const expected: TranslationResource[] = [{ id: 1, name: 'WBW', lang: 'English' }];
+    expect(result).toEqual(expected);
   });
 
   it('throws on fetch error', async () => {

--- a/lib/api/tafsir.ts
+++ b/lib/api/tafsir.ts
@@ -1,6 +1,7 @@
+import { TafsirResource } from '@/types';
 import { apiFetch } from './client';
 
-export interface TafsirResource {
+interface ApiTafsirResource {
   id: number;
   slug: string;
   name: string;
@@ -8,12 +9,16 @@ export interface TafsirResource {
 }
 
 export async function getTafsirResources(): Promise<TafsirResource[]> {
-  const data = await apiFetch<{ tafsirs: TafsirResource[] }>(
+  const data = await apiFetch<{ tafsirs: ApiTafsirResource[] }>(
     'resources/tafsirs',
     {},
     'Failed to fetch tafsir resources'
   );
-  return data.tafsirs as TafsirResource[];
+  return data.tafsirs.map((t) => ({
+    id: t.id,
+    name: t.name,
+    lang: t.language_name,
+  }));
 }
 
 export async function getTafsirByVerse(verseKey: string, tafsirId = 169): Promise<string> {

--- a/lib/api/translations.ts
+++ b/lib/api/translations.ts
@@ -1,20 +1,34 @@
 import { TranslationResource } from '@/types';
 import { apiFetch } from './client';
 
+interface ApiTranslationResource {
+  id: number;
+  name: string;
+  language_name: string;
+}
+
 export async function getTranslations(): Promise<TranslationResource[]> {
-  const data = await apiFetch<{ translations: TranslationResource[] }>(
+  const data = await apiFetch<{ translations: ApiTranslationResource[] }>(
     'resources/translations',
     {},
     'Failed to fetch translations'
   );
-  return data.translations as TranslationResource[];
+  return data.translations.map((t) => ({
+    id: t.id,
+    name: t.name,
+    lang: t.language_name,
+  }));
 }
 
 export async function getWordTranslations(): Promise<TranslationResource[]> {
-  const data = await apiFetch<{ translations: TranslationResource[] }>(
+  const data = await apiFetch<{ translations: ApiTranslationResource[] }>(
     'resources/translations',
     { resource_type: 'word_by_word' },
     'Failed to fetch translations'
   );
-  return data.translations as TranslationResource[];
+  return data.translations.map((t) => ({
+    id: t.id,
+    name: t.name,
+    lang: t.language_name,
+  }));
 }

--- a/types/index.ts
+++ b/types/index.ts
@@ -8,8 +8,6 @@ export * from './word';
 export * from './juz';
 export * from './bookmark';
 
-export type { TafsirResource } from '../lib/api';
-
 /**
  * Mapping and metadata for a Juz (section) of the Quran.
  */

--- a/types/tafsir.ts
+++ b/types/tafsir.ts
@@ -2,7 +2,16 @@
  * Information about a tafsir resource available to the app.
  */
 export interface TafsirResource {
+  /**
+   * Unique identifier of the tafsir resource.
+   */
   id: number;
+  /**
+   * Display name of the tafsir.
+   */
   name: string;
-  language_name: string;
+  /**
+   * Human-readable language of the tafsir.
+   */
+  lang: string;
 }

--- a/types/translation.ts
+++ b/types/translation.ts
@@ -2,7 +2,16 @@
  * Information about a translation resource available to the app.
  */
 export interface TranslationResource {
+  /**
+   * Unique identifier of the translation resource.
+   */
   id: number;
+  /**
+   * Display name of the translation.
+   */
   name: string;
-  language_name: string;
+  /**
+   * Human-readable language of the translation.
+   */
+  lang: string;
 }


### PR DESCRIPTION
## Summary
- add `TafsirResource` and `TranslationResource` interfaces to shared types
- use typed resources in tafsir/translation panel hooks and components
- normalize API helpers to return typed resources with language fields

## Testing
- `npm install`
- `npm run format` *(fails: templates/Component.template.tsx: SyntaxError)*
- `npm run lint` *(fails: token-rules/no-theme-conditionals)*
- `npx next lint --file app/(features)/surah/[surahId]/components/tafsir-panel/components/TafsirPanelContent.tsx --file app/(features)/surah/[surahId]/components/translation-panel/components/TranslationPanelContent.tsx --file app/(features)/surah/[surahId]/components/tafsir-panel/hooks/useTafsirSections.ts --file app/(features)/surah/[surahId]/components/translation-panel/hooks/useTranslationSections.ts`
- `npm run check` *(fails: templates/Component.template.tsx: SyntaxError)*
- `npm run type-check` *(fails: templates/Component.template.tsx: error TS1109)*

------
https://chatgpt.com/codex/tasks/task_b_68a4d06545dc832fa21d4830e3051834