### PR TITLE
fix: remove unused variables

### DIFF
--- a/app/(features)/juz/[juzId]/page.tsx
+++ b/app/(features)/juz/[juzId]/page.tsx
@@ -13,8 +13,6 @@ import useJuzData from '../hooks/useJuzData';
 import { JuzHeader } from './components/JuzHeader';
 import { JuzVerseList } from './components/JuzVerseList';
 
-const DEFAULT_WORD_TRANSLATION_ID = 85;
-
 export default function JuzPage({ params }: { params: Promise<{ juzId: string }> }) {
   const { juzId } = React.use(params);
 
@@ -34,9 +32,7 @@ export default function JuzPage({ params }: { params: Promise<{ juzId: string }>
     loadMoreRef,
     translationOptions,
     wordLanguageOptions,
-    wordLanguageMap,
     settings,
-    setSettings,
     activeVerse,
     reciter,
     isPlayerVisible,

--- a/app/(features)/page/[pageId]/page.tsx
+++ b/app/(features)/page/[pageId]/page.tsx
@@ -13,8 +13,6 @@ import { QuranAudioPlayer } from '@/app/shared/player';
 import { buildAudioUrl } from '@/lib/audio/reciters';
 import useVerseListing from '@/app/(features)/surah/hooks/useVerseListing';
 
-const DEFAULT_WORD_TRANSLATION_ID = 85;
-
 interface PagePageProps {
   params: Promise<{ pageId: string }>;
 }
@@ -35,9 +33,7 @@ export default function PagePage({ params }: PagePageProps) {
     loadMoreRef,
     translationOptions,
     wordLanguageOptions,
-    wordLanguageMap,
     settings,
-    setSettings,
     activeVerse,
     reciter,
     isPlayerVisible,

--- a/app/(features)/surah/[surahId]/components/ArabicFontPanel.tsx
+++ b/app/(features)/surah/[surahId]/components/ArabicFontPanel.tsx
@@ -21,7 +21,7 @@ export const ArabicFontPanel: React.FC<ArabicFontPanelProps> = ({ isOpen, onClos
     selectedIds,
     handleSelectionToggle,
     handleReset,
-  } = useArabicFontPanel(isOpen);
+  } = useArabicFontPanel();
 
   const listContainerRef = useRef<HTMLDivElement>(null);
   const [listHeight, setListHeight] = useState(0);

--- a/app/(features)/surah/[surahId]/components/FontSettings.tsx
+++ b/app/(features)/surah/[surahId]/components/FontSettings.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { FontSettingIcon } from '@/app/shared/icons';
 import { CollapsibleSection } from './CollapsibleSection';

--- a/app/(features)/surah/[surahId]/components/ReadingSettings.tsx
+++ b/app/(features)/surah/[surahId]/components/ReadingSettings.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React from 'react';
-import { useTranslation } from 'react-i18next';
 import { BookReaderIcon } from '@/app/shared/icons';
 import { CollapsibleSection } from './CollapsibleSection';
 
@@ -11,8 +10,6 @@ interface ReadingSettingsProps {
 }
 
 export const ReadingSettings = ({ isOpen = false, onToggle }: ReadingSettingsProps) => {
-  const { t } = useTranslation();
-
   return (
     <CollapsibleSection
       title="Mushaf Settings"

--- a/app/(features)/surah/[surahId]/components/SettingsContent.tsx
+++ b/app/(features)/surah/[surahId]/components/SettingsContent.tsx
@@ -42,11 +42,8 @@ export const SettingsContent = ({
         <TranslationSettings
           onTranslationPanelOpen={onTranslationPanelOpen}
           onWordLanguagePanelOpen={onWordLanguagePanelOpen}
-          onTafsirPanelOpen={onTafsirPanelOpen}
           selectedTranslationName={selectedTranslationName}
-          selectedTafsirName={selectedTafsirName}
           selectedWordLanguageName={selectedWordLanguageName}
-          showTafsirSetting={showTafsirSetting}
           isOpen={openSections.includes('translation')}
           onToggle={() => onSectionToggle('translation')}
         />

--- a/app/(features)/surah/[surahId]/components/SettingsSidebar.tsx
+++ b/app/(features)/surah/[surahId]/components/SettingsSidebar.tsx
@@ -44,7 +44,6 @@ export const SettingsSidebar = ({
   onTafsirPanelClose,
   isWordLanguagePanelOpen = false,
   onWordLanguagePanelClose,
-  pageType,
 }: SettingsSidebarProps) => {
   const { isSettingsOpen, setSettingsOpen } = useSidebar();
   const [isArabicFontPanelOpen, setIsArabicFontPanelOpen] = useState(false);

--- a/app/(features)/surah/[surahId]/components/SidebarContent.tsx
+++ b/app/(features)/surah/[surahId]/components/SidebarContent.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React, { forwardRef } from 'react';
-import { useTranslation } from 'react-i18next';
 import { ArrowLeftIcon } from '@/app/shared/icons';
 import { ArabicFontPanel } from './ArabicFontPanel';
 import { TranslationSettings } from './TranslationSettings';
@@ -52,7 +51,6 @@ export const SidebarContent = forwardRef<HTMLElement, SidebarContentProps>(
     },
     ref
   ) => {
-    const { t } = useTranslation();
     return (
       <aside
         ref={ref}
@@ -87,11 +85,8 @@ export const SidebarContent = forwardRef<HTMLElement, SidebarContentProps>(
               <TranslationSettings
                 onTranslationPanelOpen={onTranslationPanelOpen}
                 onWordLanguagePanelOpen={onWordLanguagePanelOpen}
-                onTafsirPanelOpen={onTafsirPanelOpen}
                 selectedTranslationName={selectedTranslationName}
-                selectedTafsirName={selectedTafsirName}
                 selectedWordLanguageName={selectedWordLanguageName}
-                showTafsirSetting={showTafsirSetting}
                 isOpen={openSections.includes('translation')}
                 onToggle={() => onToggleSection('translation')}
               />

--- a/app/(features)/surah/[surahId]/components/TafsirSettings.tsx
+++ b/app/(features)/surah/[surahId]/components/TafsirSettings.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { BookReaderIcon } from '@/app/shared/icons';
 import { CollapsibleSection } from './CollapsibleSection';

--- a/app/(features)/surah/[surahId]/components/TranslationSettings.tsx
+++ b/app/(features)/surah/[surahId]/components/TranslationSettings.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState } from 'react';
+import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { TranslationIcon } from '@/app/shared/icons';
 import { CollapsibleSection } from './CollapsibleSection';
@@ -10,11 +10,8 @@ import SelectionBox from '@/app/shared/SelectionBox';
 interface TranslationSettingsProps {
   onTranslationPanelOpen: () => void;
   onWordLanguagePanelOpen: () => void;
-  onTafsirPanelOpen?: () => void;
   selectedTranslationName: string;
-  selectedTafsirName?: string;
   selectedWordLanguageName: string;
-  showTafsirSetting?: boolean;
   isOpen?: boolean;
   onToggle?: () => void;
 }
@@ -22,11 +19,8 @@ interface TranslationSettingsProps {
 export const TranslationSettings = ({
   onTranslationPanelOpen,
   onWordLanguagePanelOpen,
-  onTafsirPanelOpen,
   selectedTranslationName,
-  selectedTafsirName,
   selectedWordLanguageName,
-  showTafsirSetting = false,
   isOpen = false,
   onToggle,
 }: TranslationSettingsProps) => {

--- a/app/(features)/surah/[surahId]/components/arabic-font-panel/useArabicFontPanel.ts
+++ b/app/(features)/surah/[surahId]/components/arabic-font-panel/useArabicFontPanel.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useTheme } from '@/app/providers/ThemeContext';
 import { useSettings } from '@/app/providers/SettingsContext';
 
@@ -14,7 +14,7 @@ interface ArabicFont {
   lang: string;
 }
 
-export const useArabicFontPanel = (isOpen: boolean) => {
+export const useArabicFontPanel = () => {
   const { theme } = useTheme();
   const { settings, setSettings, arabicFonts } = useSettings();
   const [activeFilter, setActiveFilter] = useState('Uthmani');

--- a/app/(features)/tafsir/[surahId]/[ayahId]/page.tsx
+++ b/app/(features)/tafsir/[surahId]/[ayahId]/page.tsx
@@ -15,7 +15,6 @@ export default function TafsirVersePage({ params }: TafsirVersePageProps) {
     verse,
     tafsirHtml,
     tafsirResource,
-    wordLanguageOptions,
     selectedTranslationName,
     selectedTafsirName,
     selectedWordLanguageName,
@@ -23,7 +22,6 @@ export default function TafsirVersePage({ params }: TafsirVersePageProps) {
     next,
     navigate,
     currentSurah,
-    resetWordSettings,
   } = useTafsirVerseData(surahId, ayahId);
 
   const [isTranslationPanelOpen, setIsTranslationPanelOpen] = useState(false);

--- a/app/providers/__tests__/BookmarkContext.test.tsx
+++ b/app/providers/__tests__/BookmarkContext.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor, act } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { BookmarkProvider, useBookmarks } from '@/app/providers/BookmarkContext';
 import { Folder } from '@/types';


### PR DESCRIPTION
## Summary
- remove unused variables from Juz and Page routes
- clean up unused props and imports in surah settings components
- drop unused hooks and parameters from Arabic font panel

## Testing
- `npm run lint`
- `npm test` *(fails: renders list of tafsir links, renders list of surah links)*


------
https://chatgpt.com/codex/tasks/task_b_68a4d07784dc832fba2e8b6bd359035b