### PR TITLE
build: remove next-i18next integration

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+templates

--- a/next-i18next.config.mjs
+++ b/next-i18next.config.mjs
@@ -1,8 +1,0 @@
-export default {
-  i18n: {
-    defaultLocale: 'en',
-    locales: ['en', 'bn'],
-  },
-  ns: ['common', 'player'],
-  defaultNS: 'common',
-};

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,4 @@
 import type { NextConfig } from 'next';
-import nextI18NextConfig from './next-i18next.config.mjs';
 import nextPwa, { type PWAConfig } from 'next-pwa';
 import pwaConfig from './next-pwa.config.mjs';
 
@@ -32,11 +31,7 @@ const securityHeaders = [
 ];
 
 const nextConfig: NextConfig = {
-  // --- MERGED CONFIGURATIONS ---
-  // 1. Add i18n configuration
-  i18n: nextI18NextConfig.i18n,
-
-  // 2. Expose the Quran API base URL to the app
+  // Expose the Quran API base URL to the app
   env: {
     QURAN_API_BASE_URL: process.env.QURAN_API_BASE_URL,
   },
@@ -44,7 +39,7 @@ const nextConfig: NextConfig = {
   outputFileTracingExcludes:
     process.env.NODE_ENV === 'production' ? { '*': ['app/(dev)/**'] } : undefined,
 
-  // 3. Add security headers
+  // Add security headers
   async headers() {
     return [
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "i18next": "^25.3.2",
         "lucide-react": "^0.539.0",
         "next": "^15.4.6",
-        "next-i18next": "^15.4.2",
         "next-pwa": "^5.6.0",
         "react": "19.1.1",
         "react-dom": "19.1.1",
@@ -7036,18 +7035,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/hoist-non-react-statics": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.7.tgz",
-      "integrity": "sha512-PQTyIulDkIDro8P+IHbKCsw7U2xxBYflVzW/FgWdCAePD9xGSidgA76/GeJ6lBKoblyhf9pBY763gbrN+1dI8g==",
-      "license": "MIT",
-      "dependencies": {
-        "hoist-non-react-statics": "^3.3.0"
-      },
-      "peerDependencies": {
-        "@types/react": "*"
-      }
-    },
     "node_modules/@types/html-minifier-terser": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
@@ -7507,6 +7494,7 @@
       "version": "19.1.10",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.10.tgz",
       "integrity": "sha512-EhBeSYX0Y6ye8pNebpKrwFJq7BoQ8J5SO6NlvNwwHjSj6adXJViPQrKlsyPw7hLBLvckEMO1yxeGdR82YBBlDg==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -10077,17 +10065,6 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "license": "MIT"
     },
-    "node_modules/core-js": {
-      "version": "3.45.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.45.0.tgz",
-      "integrity": "sha512-c2KZL9lP4DjkN3hk/an4pWn5b5ZefhRJnAc42n6LJ19kSnbeRbdQZE5dSeE2LBol1OwJD3X1BQvFTAsa8ReeDA==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
-      }
-    },
     "node_modules/core-js-compat": {
       "version": "3.45.0",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.45.0.tgz",
@@ -10402,6 +10379,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -12829,15 +12807,6 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
-    "node_modules/hoist-non-react-statics": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
-      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "react-is": "^16.7.0"
-      }
-    },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
@@ -13054,12 +13023,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/i18next-fs-backend": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/i18next-fs-backend/-/i18next-fs-backend-2.6.0.tgz",
-      "integrity": "sha512-3ZlhNoF9yxnM8pa8bWp5120/Ob6t4lVl1l/tbLmkml/ei3ud8IWySCHt2lrY5xWRlSU5D9IV2sm5bEbGuTqwTw==",
-      "license": "MIT"
     },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
@@ -15860,42 +15823,6 @@
         }
       }
     },
-    "node_modules/next-i18next": {
-      "version": "15.4.2",
-      "resolved": "https://registry.npmjs.org/next-i18next/-/next-i18next-15.4.2.tgz",
-      "integrity": "sha512-zgRxWf7kdXtM686ecGIBQL+Bq0+DqAhRlasRZ3vVF0TmrNTWkVhs52n//oU3Fj5O7r/xOKkECDUwfOuXVwTK/g==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://locize.com/i18next.html"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
-        },
-        {
-          "type": "individual",
-          "url": "https://locize.com"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.23.2",
-        "@types/hoist-non-react-statics": "^3.3.6",
-        "core-js": "^3",
-        "hoist-non-react-statics": "^3.3.2",
-        "i18next-fs-backend": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "i18next": ">= 23.7.13",
-        "next": ">= 12.0.0",
-        "react": ">= 17.0.2",
-        "react-i18next": ">= 13.5.0"
-      }
-    },
     "node_modules/next-pwa": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/next-pwa/-/next-pwa-5.6.0.tgz",
@@ -17500,6 +17427,7 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/react-refresh": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "i18next": "^25.3.2",
     "lucide-react": "^0.539.0",
     "next": "^15.4.6",
-    "next-i18next": "^15.4.2",
     "next-pwa": "^5.6.0",
     "react": "19.1.1",
     "react-dom": "19.1.1",


### PR DESCRIPTION
## Summary
- remove deprecated next-i18next config and i18n property
- drop next-i18next dependency and add prettier ignore for templates

## Testing
- `npm run check` *(fails: Avoid theme conditionals & other lint errors)*
- `npm test app/__tests__/not-found.bn.test.tsx`


------
https://chatgpt.com/codex/tasks/task_b_68a4d15959c0832f9837ec041d5d6408