### PR TITLE
fix: hoist rollup-plugin-terser dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "node-fetch": "^3.3.2",
         "prettier": "^3.6.2",
         "rimraf": "^4",
+        "rollup-plugin-terser": "file:packages/rollup-plugin-terser",
         "storybook": "^8.4.3",
         "tailwindcss": "^3.4.17",
         "ts-jest": "^29.4.1",
@@ -17845,7 +17846,7 @@
       }
     },
     "node_modules/rollup-plugin-terser": {
-      "resolved": "node_modules/workbox-build/packages/rollup-plugin-terser",
+      "resolved": "packages/rollup-plugin-terser",
       "link": true
     },
     "node_modules/rrweb-cssom": {
@@ -20739,7 +20740,9 @@
         "webidl-conversions": "^4.0.2"
       }
     },
-    "node_modules/workbox-build/packages/rollup-plugin-terser": {},
+    "node_modules/workbox-build/packages/rollup-plugin-terser": {
+      "extraneous": true
+    },
     "node_modules/workbox-cacheable-response": {
       "version": "6.6.0",
       "resolved": "https://registry.npmjs.org/workbox-cacheable-response/-/workbox-cacheable-response-6.6.0.tgz",
@@ -21170,6 +21173,9 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "packages/rollup-plugin-terser": {
+      "version": "0.4.4"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "eslint-plugin-prettier": "^5.5.3",
     "rimraf": "^4",
     "@rollup/plugin-terser": "^0.4.4",
+    "rollup-plugin-terser": "file:packages/rollup-plugin-terser",
     "jest": "^30.0.5",
     "jest-environment-jsdom": "^30.0.5",
     "node-fetch": "^3.3.2",


### PR DESCRIPTION
## Summary
- hoist rollup-plugin-terser by adding local package to devDependencies

## Testing
- `npm install`
- `npm run check` *(fails: Type 'TafsirResource[]' is not assignable to type 'Tafsir[]')*
- `npm run build` *(fails: Type 'TafsirResource[]' is not assignable to type 'Tafsir[]')*


------
https://chatgpt.com/codex/tasks/task_b_68a51bc5411c832f9254f2a4dfbb4e03