### PR TITLE
feat: add mobile nav bar

### DIFF
--- a/app/(features)/layout.tsx
+++ b/app/(features)/layout.tsx
@@ -4,6 +4,7 @@ import { usePathname } from 'next/navigation';
 import Header from '@/app/shared/Header';
 import IconSidebar from '@/app/shared/IconSidebar';
 import SurahListSidebar from '@/app/shared/SurahListSidebar';
+import MobileNav from '@/app/shared/MobileNav';
 import {
   HeaderVisibilityProvider,
   useHeaderVisibility,
@@ -21,9 +22,9 @@ function LayoutContent({ children }: { children: React.ReactNode }) {
       <Header />
       <div className="flex flex-col h-screen">
         <div
-          className={`flex flex-grow overflow-hidden min-h-0 transition-[padding-top] duration-300 ${isHidden ? 'pt-0' : 'pt-16'}`}
+          className={`flex flex-grow overflow-hidden min-h-0 transition-[padding-top] duration-300 ${isHidden ? 'pt-0' : 'pt-16'} pb-16 md:pb-0`}
         >
-          <nav aria-label="Primary navigation" className="flex-shrink-0 h-full">
+          <nav aria-label="Primary navigation" className="hidden md:flex flex-shrink-0 h-full">
             <IconSidebar />
           </nav>
           {/*
@@ -38,6 +39,7 @@ function LayoutContent({ children }: { children: React.ReactNode }) {
           )}
           {children}
         </div>
+        <MobileNav />
       </div>
     </>
   );

--- a/app/shared/MobileNav.tsx
+++ b/app/shared/MobileNav.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import Link from 'next/link';
+import { useTranslation } from 'react-i18next';
+import { HomeIcon, GridIcon, BookmarkOutlineIcon } from './icons';
+
+const MobileNav = () => {
+  const { t } = useTranslation();
+  const navItems = [
+    { icon: HomeIcon, label: t('home'), href: '/' },
+    { icon: GridIcon, label: t('all_surahs'), href: '/surah/1' },
+    { icon: BookmarkOutlineIcon, label: t('bookmarks'), href: '/bookmarks' },
+  ];
+
+  return (
+    <nav className="fixed bottom-0 left-0 right-0 h-16 bg-background text-foreground border-t border-border flex items-center justify-around md:hidden">
+      {navItems.map((item) => (
+        <Link
+          key={item.href}
+          href={item.href}
+          title={item.label}
+          aria-label={item.label}
+          className="p-3 hover:text-accent transition-colors duration-200"
+        >
+          <item.icon className="h-6 w-6" />
+        </Link>
+      ))}
+    </nav>
+  );
+};
+
+export default MobileNav;


### PR DESCRIPTION
## Summary
- show IconSidebar only on medium screens and up
- add bottom mobile navigation with home, surah and bookmarks links
- pad content bottom to avoid overlap on mobile

## Testing
- `npm install`
- `npm run format`
- `npm run lint`
- `npm run check` *(fails: TestingLibraryElementError: Unable to find an element with the text: Al-Fatihah)*

------
https://chatgpt.com/codex/tasks/task_b_68a6f21e1204832f94d9ac0ae0f236ae