### PR TITLE
fix: use dynamic viewport height

### DIFF
--- a/app/(features)/home/components/HomePage.tsx
+++ b/app/(features)/home/components/HomePage.tsx
@@ -23,7 +23,7 @@ export default function HomePage() {
   const [searchQuery, setSearchQuery] = useState('');
 
   return (
-    <div className="relative h-screen flex flex-col bg-background text-foreground overflow-hidden">
+    <div className="relative min-h-[100dvh] flex flex-col bg-background text-foreground overflow-hidden">
       <HomePageBackground />
 
       <div className="relative z-10 flex flex-col h-full overflow-y-auto px-4 sm:px-6 lg:px-8 homepage-scrollable-area">

--- a/app/(features)/layout.tsx
+++ b/app/(features)/layout.tsx
@@ -19,7 +19,7 @@ function LayoutContent({ children }: { children: React.ReactNode }) {
   return (
     <>
       <Header />
-      <div className="flex flex-col h-screen">
+      <div className="flex flex-col min-h-[100dvh]">
         <div
           className={`flex flex-grow overflow-hidden min-h-0 transition-[padding-top] duration-300 ${isHidden ? 'pt-0' : 'pt-16'}`}
         >


### PR DESCRIPTION
## Summary
- replace `h-screen` with `min-h-[100dvh]` in features layout
- use dynamic viewport height for home page container
- remove remaining `h-screen` usages

## Testing
- `npm run lint`
- `npm run check` *(fails: IndexPage tests)*

------
https://chatgpt.com/codex/tasks/task_b_68a6f21ef65c832fa0bd393933625096