### PR TITLE
feat: add viewport metadata

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -69,6 +69,7 @@ const libreBaskerville = Libre_Baskerville({
 export const metadata = {
   title: 'Quran Mazid',
   description: 'Read, Study, and Learn The Holy Quran',
+  viewport: { width: 'device-width', initialScale: 1 },
 };
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {


### PR DESCRIPTION
## Summary
- add viewport settings to root layout metadata

## Testing
- `npm install`
- `npm run format`
- `npm run lint`
- `npm run check` *(fails: renders list of tafsir links; renders list of surah links)*
- `npm run build`
- `npm run start`
- `curl -s http://localhost:3000 | perl -pe 's/>/>
/g' | head -n 20`


------
https://chatgpt.com/codex/tasks/task_b_68a6f21f3120832fa2c7ccc2088916ca