### PR TITLE
fix: restore safe-area padding utilities

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -202,6 +202,16 @@
     @apply transition-transform duration-300 ease-in-out;
   }
 
+  /* Safe area support for mobile devices */
+  .pb-safe {
+    padding-bottom: max(1rem, env(safe-area-inset-bottom));
+  }
+
+  /* Bottom navigation spacing */
+  .bottom-nav-space {
+    padding-bottom: calc(5rem + env(safe-area-inset-bottom));
+  }
+
   /* Scrollbar hiding for cleaner mobile experience */
   .scrollbar-hide {
     -ms-overflow-style: none;


### PR DESCRIPTION
## Summary
- reintroduce `pb-safe` utility for bottom padding with safe-area support
- add `bottom-nav-space` to account for safe-area inset on fixed navigation

## Testing
- `npm install`
- `npm run format`
- `npm run lint` *(fails: Avoid theme conditionals in className; Unexpected any; and more)*
- `npm run check` *(fails: Avoid theme conditionals in className; Unexpected any; and more)*

------
https://chatgpt.com/codex/tasks/task_b_68a7b507f9cc832fa99704488f184a13