### PR TITLE
Refactor useBreakpoint to use matchMedia

### DIFF
--- a/lib/__tests__/responsive.test.ts
+++ b/lib/__tests__/responsive.test.ts
@@ -1,0 +1,37 @@
+import { renderHook } from '@testing-library/react';
+import { useBreakpoint } from '../responsive';
+
+const createMatchMedia = (width: number) => (query: string) => ({
+  matches: width >= parseInt(query.match(/\d+/)![0], 10),
+  media: query,
+  onchange: null,
+  addEventListener: jest.fn(),
+  removeEventListener: jest.fn(),
+  dispatchEvent: jest.fn(),
+});
+
+describe('useBreakpoint', () => {
+  it('returns mobile when width is below 768px', () => {
+    window.matchMedia = jest.fn(createMatchMedia(500)) as any;
+    const { result } = renderHook(() => useBreakpoint());
+    expect(result.current).toBe('mobile');
+  });
+
+  it('returns tablet when width is between 768px and 1023px', () => {
+    window.matchMedia = jest.fn(createMatchMedia(800)) as any;
+    const { result } = renderHook(() => useBreakpoint());
+    expect(result.current).toBe('tablet');
+  });
+
+  it('returns desktop when width is between 1024px and 1279px', () => {
+    window.matchMedia = jest.fn(createMatchMedia(1100)) as any;
+    const { result } = renderHook(() => useBreakpoint());
+    expect(result.current).toBe('desktop');
+  });
+
+  it('returns wide when width is at least 1280px', () => {
+    window.matchMedia = jest.fn(createMatchMedia(1300)) as any;
+    const { result } = renderHook(() => useBreakpoint());
+    expect(result.current).toBe('wide');
+  });
+});


### PR DESCRIPTION
## Summary
- compute breakpoints in a stateful hook using `matchMedia`
- add `useResponsiveValue` helper and generics for responsive configs
- expose display names for responsive components and simplify responsive state
- cover breakpoint detection with unit tests

## Testing
- `npm test lib/__tests__/responsive.test.ts`
- `npm run lint` *(fails: Avoid theme conditionals in className, Unexpected any etc.)*

------
https://chatgpt.com/codex/tasks/task_b_68a7b5b689e4832f9b8e5e6f4edcb172