### PR TITLE
fix: use dvh units for full-height layouts

### DIFF
--- a/app/(features)/layout.tsx
+++ b/app/(features)/layout.tsx
@@ -20,7 +20,7 @@ function LayoutContent({ children }: { children: React.ReactNode }) {
   return (
     <ModernLayout>
       <Header />
-      <div className="flex flex-col h-screen">
+      <div className="flex flex-col min-h-[100dvh]">
         <div
           className={`flex flex-grow overflow-hidden min-h-0 transition-[padding-top] duration-300 ${isHidden ? 'pt-0' : 'pt-16'}`}
         >

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 export default function NotFound() {
   const { t } = useTranslation();
   return (
-    <div className="min-h-screen flex flex-col items-center justify-center bg-background text-foreground p-6">
+    <div className="min-h-[100dvh] flex flex-col items-center justify-center bg-background text-foreground p-6">
       <h1 className="text-2xl font-semibold mb-4">{t('page_not_found')}</h1>
       <Link
         href="/"

--- a/app/shared/components/AdaptiveLayout.tsx
+++ b/app/shared/components/AdaptiveLayout.tsx
@@ -85,7 +85,7 @@ const AdaptiveLayout: React.FC<AdaptiveLayoutProps> = ({
   };
 
   return (
-    <div className="relative min-h-screen bg-background">
+    <div className="relative min-h-[100dvh] bg-background">
       {/* Backdrop for mobile sidebar */}
       <AnimatePresence>
         {sidebarOpen && variant === 'compact' && (

--- a/app/shared/navigation/ModernLayout.tsx
+++ b/app/shared/navigation/ModernLayout.tsx
@@ -48,7 +48,7 @@ const ModernLayout: React.FC<ModernLayoutProps> = ({
     <>
       {/* Main content with bottom padding for navigation */}
       <SwipeContainer
-        className={`min-h-screen ${shouldShowBottomNav ? 'bottom-nav-space lg:pb-0' : ''}`}
+        className={`min-h-[100dvh] ${shouldShowBottomNav ? 'bottom-nav-space lg:pb-0' : ''}`}
       >
         {children}
       </SwipeContainer>


### PR DESCRIPTION
## Summary
- replace h-screen/min-h-screen with min-h-[100dvh]
- search repository for remaining h-screen references

## Testing
- `npm run format`
- `npm run lint` (fails: Avoid theme conditionals, raw color utilities, no-unescaped-entities, unexpected any, etc.)
- `CI=1 npm run check` (fails: lint errors)

------
https://chatgpt.com/codex/tasks/task_b_68a7b994ee98832fb42ecc2f84e154e3