### PR TITLE
fix: use touch-pan-y class in SwipeContainer

### DIFF
--- a/app/shared/navigation/SwipeContainer.tsx
+++ b/app/shared/navigation/SwipeContainer.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { useRouter, usePathname } from 'next/navigation';
 import { useSwipeGestures } from '@/app/shared/hooks/useSwipeGestures';
 import { useNavigation } from '@/app/providers/NavigationContext';
+import { cn } from '@/lib/utils';
 
 interface SwipeContainerProps {
   children: React.ReactNode;
@@ -53,9 +54,8 @@ const SwipeContainer: React.FC<SwipeContainerProps> = ({ children, className }) 
   return (
     <div
       {...swipeGestures}
-      className={className}
+      className={cn('touch-pan-y select-none', className)}
       style={{
-        touchAction: 'pan-y', // Allow vertical scrolling but handle horizontal swipes
         WebkitTouchCallout: 'none', // Disable iOS context menu
         WebkitUserSelect: 'none', // Disable text selection during swipes
       }}


### PR DESCRIPTION
## Summary
- replace inline touch-action with `touch-pan-y` and `select-none`
- keep WebKit touch callout and user select styles

## Testing
- `npm run format`
- `npm run lint` *(fails: `Avoid theme conditionals in className`)*
- `npm run check` *(fails: `Avoid theme conditionals in className`)*

------
https://chatgpt.com/codex/tasks/task_b_68a7b9b696dc832fbd425724d433273c