### PR TITLE
refactor: use breakpoint hook in swipe indicator

### DIFF
--- a/app/shared/navigation/SwipeIndicator.tsx
+++ b/app/shared/navigation/SwipeIndicator.tsx
@@ -3,6 +3,7 @@
 import React, { useState, useEffect } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { IconChevronLeft, IconChevronRight, IconArrowDown } from '@tabler/icons-react';
+import { useBreakpoint } from '@/lib/responsive';
 
 interface SwipeIndicatorProps {
   show?: boolean;
@@ -27,14 +28,8 @@ const SwipeIndicator: React.FC<SwipeIndicatorProps> = ({
     }
   }, [autoHide, autoHideDelay, show]);
 
-  // Don't show on desktop
-  const [isMobile, setIsMobile] = useState(false);
-  useEffect(() => {
-    const checkMobile = () => setIsMobile(window.innerWidth < 1024);
-    checkMobile();
-    window.addEventListener('resize', checkMobile);
-    return () => window.removeEventListener('resize', checkMobile);
-  }, []);
+  const breakpoint = useBreakpoint();
+  const isMobile = breakpoint === 'mobile' || breakpoint === 'tablet';
 
   if (!isMobile) return null;
 


### PR DESCRIPTION
## Summary
- use `useBreakpoint` hook instead of manual window width checks

## Testing
- `npm run lint` *(fails: Unexpected any in AdaptiveNavigation.tsx, QuickSearch.tsx, etc.)*
- `npm run check` *(fails: Unexpected any in AdaptiveNavigation.tsx, QuickSearch.tsx, etc.)*

------
https://chatgpt.com/codex/tasks/task_b_68a7bd723a94832f96e6d5aa465d3f02