### PR TITLE
fix: toggle body classes for scroll lock

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -244,6 +244,15 @@
   .z-modal {
     z-index: var(--z-modal);
   }
+
+  /* Body scroll/interaction helpers */
+  .overflow-hidden {
+    overflow: hidden;
+  }
+
+  .touch-none {
+    touch-action: none;
+  }
 }
 
 /* ===== Custom Range Slider Styles ===== */

--- a/app/providers/NavigationContext.tsx
+++ b/app/providers/NavigationContext.tsx
@@ -67,19 +67,17 @@ export const NavigationProvider = ({ children }: { children: React.ReactNode }) 
     const shouldPreventScroll = isQuranBottomSheetOpen;
 
     if (typeof window !== 'undefined') {
+      const { classList } = document.body;
       if (shouldPreventScroll) {
-        document.body.style.overflow = 'hidden';
-        document.body.style.touchAction = 'none';
+        classList.add('overflow-hidden', 'touch-none');
       } else {
-        document.body.style.overflow = '';
-        document.body.style.touchAction = '';
+        classList.remove('overflow-hidden', 'touch-none');
       }
     }
 
     return () => {
       if (typeof window !== 'undefined') {
-        document.body.style.overflow = '';
-        document.body.style.touchAction = '';
+        document.body.classList.remove('overflow-hidden', 'touch-none');
       }
     };
   }, [isQuranBottomSheetOpen]);


### PR DESCRIPTION
## Summary
- add overflow-hidden and touch-none utility classes
- toggle body classes for scroll lock in NavigationContext

## Testing
- `npm run lint` *(fails: Unexpected any, Click events have key events, no-static-element-interactions, no-unescaped-entities)*
- `npm run check` *(fails: Unexpected any, Click events have key events, no-static-element-interactions, no-unescaped-entities)*

------
https://chatgpt.com/codex/tasks/task_b_68a7bd785bd0832f89cf24e602355555