### PR TITLE
fix: use touch-none on Quran sheet backdrop

### DIFF
--- a/app/shared/navigation/QuranBottomSheet.tsx
+++ b/app/shared/navigation/QuranBottomSheet.tsx
@@ -65,9 +65,8 @@ const QuranBottomSheet: React.FC<QuranBottomSheetProps> = ({ isOpen, onClose, on
             initial="hidden"
             animate="visible"
             exit="hidden"
-            className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50"
+            className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 touch-none"
             onClick={onClose}
-            style={{ touchAction: 'none' }}
           />
 
           {/* Bottom Sheet */}


### PR DESCRIPTION
## Summary
- remove inline touchAction style from Quran bottom sheet backdrop
- add touch-none class to prevent touch actions via Tailwind

## Testing
- `npm run format`
- `npm run lint` *(fails: `Unexpected any` and `jsx-a11y/no-static-element-interactions`)*
- `npm run check` *(fails: `Unexpected any` and `jsx-a11y/no-static-element-interactions`)*

------
https://chatgpt.com/codex/tasks/task_b_68a7c7056d84832f80a3ef8ab64eebbc