### PR TITLE
fix: add pb-safe to audio player wrappers

### DIFF
--- a/app/(features)/juz/[juzId]/page.tsx
+++ b/app/(features)/juz/[juzId]/page.tsx
@@ -117,7 +117,7 @@ export default function JuzPage({ params }: { params: Promise<{ juzId: string }>
         onWordLanguagePanelClose={() => setIsWordPanelOpen(false)}
       />
       {activeVerse && isPlayerVisible && (
-        <div className="fixed bottom-0 left-0 right-0 p-4 bg-transparent z-50">
+        <div className="fixed bottom-0 left-0 right-0 p-4 pb-safe bg-transparent z-50">
           <QuranAudioPlayer track={track} onNext={handleNext} onPrev={handlePrev} />
         </div>
       )}

--- a/app/(features)/page/[pageId]/page.tsx
+++ b/app/(features)/page/[pageId]/page.tsx
@@ -115,7 +115,7 @@ export default function PagePage({ params }: PagePageProps) {
         onWordLanguagePanelClose={() => setIsWordPanelOpen(false)}
       />
       {activeVerse && isPlayerVisible && (
-        <div className="fixed bottom-0 left-0 right-0 p-4 bg-transparent z-50">
+        <div className="fixed bottom-0 left-0 right-0 p-4 pb-safe bg-transparent z-50">
           <QuranAudioPlayer track={track} onNext={handleNext} onPrev={handlePrev} />
         </div>
       )}

--- a/app/(features)/surah/[surahId]/components/SurahAudioPlayer.tsx
+++ b/app/(features)/surah/[surahId]/components/SurahAudioPlayer.tsx
@@ -43,7 +43,7 @@ export const SurahAudioPlayer = ({
   };
 
   return (
-    <div className="fixed bottom-0 left-0 right-0 p-4 bg-transparent z-50">
+    <div className="fixed bottom-0 left-0 right-0 p-4 pb-safe bg-transparent z-50">
       <QuranAudioPlayer track={track} onNext={onNext} onPrev={onPrev} />
     </div>
   );


### PR DESCRIPTION
## Summary
- add pb-safe to surah, page, and juz audio player wrappers

## Testing
- `npm run format`
- `npm run lint` *(fails: Unexpected any, a11y warnings, etc)*
- `npm run check` *(fails: Unexpected any, a11y warnings, etc)*

------
https://chatgpt.com/codex/tasks/task_b_68a7c7188684832fbce22d893abadc90