### PR TITLE
fix: use bottom nav space utility

### DIFF
--- a/lib/responsive.ts
+++ b/lib/responsive.ts
@@ -186,7 +186,7 @@ export const layoutPatterns = {
 
   // Content area that works with any navigation
   adaptiveContent: {
-    mobile: 'pt-14 pb-20', // Account for fixed header/nav
+    mobile: 'pt-14 bottom-nav-space', // Account for fixed header/nav and safe areas
     tablet: 'pt-16 pb-4',
     desktop: 'p-0', // No fixed elements
   },


### PR DESCRIPTION
## Summary
- replace `pb-20` with `bottom-nav-space` in responsive layout patterns

## Testing
- `npm run lint` *(fails: 'Unexpected any. Specify a different type.' in AdaptiveNavigation.tsx)*
- `npm run check` *(fails: 'Unexpected any. Specify a different type.' in AdaptiveNavigation.tsx)*

------
https://chatgpt.com/codex/tasks/task_b_68a7c72ae4ec832f80dc0edf0cfd0f64