### PR TITLE
fix: offset swipe indicator for safe area

### DIFF
--- a/app/shared/navigation/SwipeIndicator.tsx
+++ b/app/shared/navigation/SwipeIndicator.tsx
@@ -41,7 +41,8 @@ const SwipeIndicator: React.FC<SwipeIndicatorProps> = ({
           animate={{ opacity: 1, y: 0 }}
           exit={{ opacity: 0, y: 20 }}
           transition={{ duration: 0.3 }}
-          className="fixed bottom-20 left-4 right-4 z-30 pointer-events-none"
+          className="fixed left-4 right-4 z-30 pointer-events-none"
+          style={{ bottom: 'calc(5rem + env(safe-area-inset-bottom))' }}
         >
           <div className="bg-black/70 backdrop-blur-sm text-white rounded-2xl p-4 mx-auto max-w-sm">
             <div className="text-center mb-3">


### PR DESCRIPTION
## Summary
- use `env(safe-area-inset-bottom)` to offset swipe indicator from bottom navigation

## Testing
- `npm run lint` (fails: Unexpected any in AdaptiveNavigation etc.)
- `npm run check` (fails: Unexpected any in AdaptiveNavigation etc.)

------
https://chatgpt.com/codex/tasks/task_b_68a7c7250790832fb4e5dbf004c918b8