### PR TITLE
fix: ensure bottom navigation spacing across devices

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -221,6 +221,7 @@
 
   /* Bottom navigation spacing */
   .bottom-nav-space {
+    padding-bottom: 5rem;
     padding-bottom: calc(5rem + env(safe-area-inset-bottom));
   }
 

--- a/app/shared/components/AdaptiveLayout.tsx
+++ b/app/shared/components/AdaptiveLayout.tsx
@@ -39,13 +39,13 @@ const AdaptiveLayout: React.FC<AdaptiveLayoutProps> = ({
 
     switch (variant) {
       case 'compact':
-        return 'pb-20'; // Mobile bottom nav height
+        return 'bottom-nav-space'; // Mobile bottom nav height
       case 'default':
-        return 'pb-20'; // Tablet also uses bottom nav
+        return 'bottom-nav-space'; // Tablet also uses bottom nav
       case 'expanded':
         return ''; // Desktop has no fixed navigation
       default:
-        return 'pb-20';
+        return 'bottom-nav-space';
     }
   };
 


### PR DESCRIPTION
## Summary
- use `bottom-nav-space` utility for adaptive layout padding
- add fallback padding to `bottom-nav-space` for cross-device spacing

## Testing
- `npm run lint`
- `npm run check` *(fails: SettingsSidebar interactions, Header, IndexPage tests, and others)*

------
https://chatgpt.com/codex/tasks/task_b_68a7cffef2b8832fb5ac69e5a3f65376