### PR TITLE
fix: allow dismissing swipe indicator by tap

### DIFF
--- a/app/shared/navigation/SwipeIndicator.tsx
+++ b/app/shared/navigation/SwipeIndicator.tsx
@@ -41,8 +41,9 @@ const SwipeIndicator: React.FC<SwipeIndicatorProps> = ({
           animate={{ opacity: 1, y: 0 }}
           exit={{ opacity: 0, y: 20 }}
           transition={{ duration: 0.3 }}
-          className="fixed left-4 right-4 z-30 pointer-events-none"
+          className="fixed left-4 right-4 z-30"
           style={{ bottom: 'calc(5rem + env(safe-area-inset-bottom))' }}
+          onClick={() => setIsVisible(false)}
         >
           <div className="bg-black/70 backdrop-blur-sm text-white rounded-2xl p-4 mx-auto max-w-sm">
             <div className="text-center mb-3">


### PR DESCRIPTION
## Summary
- allow tapping swipe indicator to hide it

## Testing
- `npm install`
- `npm run format`
- `npm run lint`
- `npm run check` *(fails: SettingsSidebar interactions > opens via header icon, switches font tabs, and closes with back button; Header renders the title; IndexPage renders list of tafsir links; IndexPage renders list of surah links)*

------
https://chatgpt.com/codex/tasks/task_b_68a7d02c8b90832f8afed1f702da84da