### PR TITLE
docs: remove touch-action inline style

### DIFF
--- a/app/shared/ui/ResponsivePatterns.md
+++ b/app/shared/ui/ResponsivePatterns.md
@@ -68,9 +68,7 @@ All interactive elements should meet WCAG touch target requirements:
 
 ```tsx
 // Enable touch gestures
-<div className="touch-pan-x touch-pinch-zoom" style={{ touchAction: 'pan-x pinch-zoom' }}>
-  {/* Swipeable content */}
-</div>
+<div className="touch-pan-x touch-pinch-zoom">{/* Swipeable content */}</div>
 ```
 
 #### Focus Management


### PR DESCRIPTION
## Summary
- remove inline touchAction style from touch gesture example

## Testing
- `npm run lint`
- `npm run check` *(fails: 4 test suites failed)*

------
https://chatgpt.com/codex/tasks/task_b_68a7d02f4314832f8eb40e1da09dd9d5