### PR TITLE
fix: add pt-safe to adaptive header

### DIFF
--- a/lib/__tests__/responsive.test.ts
+++ b/lib/__tests__/responsive.test.ts
@@ -1,5 +1,5 @@
 import { renderHook } from '@testing-library/react';
-import { useBreakpoint } from '../responsive';
+import { useBreakpoint, layoutPatterns } from '../responsive';
 
 const createMatchMedia = (width: number) => (query: string) => ({
   matches: width >= parseInt(query.match(/\d+/)![0], 10),
@@ -33,5 +33,12 @@ describe('useBreakpoint', () => {
     window.matchMedia = jest.fn(createMatchMedia(1300)) as any;
     const { result } = renderHook(() => useBreakpoint());
     expect(result.current).toBe('wide');
+  });
+});
+
+describe('layoutPatterns.adaptiveHeader', () => {
+  it('includes pt-safe for mobile and tablet', () => {
+    expect(layoutPatterns.adaptiveHeader.mobile).toContain('pt-safe');
+    expect(layoutPatterns.adaptiveHeader.tablet).toContain('pt-safe');
   });
 });

--- a/lib/responsive.ts
+++ b/lib/responsive.ts
@@ -179,8 +179,8 @@ export const layoutPatterns = {
 
   // Header that adapts without breaking
   adaptiveHeader: {
-    mobile: 'fixed top-0 left-0 right-0 h-14 px-3',
-    tablet: 'fixed top-0 left-0 right-0 h-16 px-4',
+    mobile: 'fixed top-0 left-0 right-0 h-14 px-3 pt-safe',
+    tablet: 'fixed top-0 left-0 right-0 h-16 px-4 pt-safe',
     desktop: 'static h-20 px-6',
   },
 


### PR DESCRIPTION
## Summary
- ensure adaptive headers include safe-area padding
- test adaptive header layout for safe-area compliance

## Testing
- `npm run format`
- `npm run lint`
- `npm run check` *(fails: SettingsSidebar interactions — unable to find label 'Open Settings'; Header — renders the title; renders list of tafsir links; renders list of surah links)*

------
https://chatgpt.com/codex/tasks/task_b_68a7d02896c0832fa1700edd5a78ce33