### PR TITLE
fix: add bottom safe padding to panels

### DIFF
--- a/app/(features)/surah/[surahId]/components/SettingsSidebar.tsx
+++ b/app/(features)/surah/[surahId]/components/SettingsSidebar.tsx
@@ -65,7 +65,7 @@ export const SettingsSidebar = ({
       )}
       <aside
         ref={sidebarRef}
-        className={`settings-sidebar fixed lg:static top-0 lg:top-0 bottom-0 right-0 w-72 sm:w-80 md:w-[20.7rem] bg-background text-foreground flex flex-col lg:flex-shrink-0 shadow-modal lg:shadow-lg border-l border-border transition-transform duration-300 ease-in-out lg:h-full overflow-x-hidden pt-safe ${
+        className={`settings-sidebar fixed lg:static top-0 lg:top-0 bottom-0 right-0 w-72 sm:w-80 md:w-[20.7rem] bg-background text-foreground flex flex-col lg:flex-shrink-0 shadow-modal lg:shadow-lg border-l border-border transition-transform duration-300 ease-in-out lg:h-full overflow-x-hidden pt-safe pb-safe ${
           isSettingsOpen ? 'translate-x-0' : 'translate-x-full'
         } lg:translate-x-0 touch-pan-y`}
         style={{

--- a/app/(features)/tafsir/[surahId]/[ayahId]/components/WordTranslationPanel.tsx
+++ b/app/(features)/tafsir/[surahId]/[ayahId]/components/WordTranslationPanel.tsx
@@ -43,7 +43,7 @@ export const WordTranslationPanel = ({
 
   return (
     <div
-      className={`fixed pt-safe ${isHidden ? 'top-0' : 'top-16'} bottom-0 right-0 w-[20.7rem] bg-surface text-foreground flex flex-col transition-all duration-300 ease-in-out z-50 shadow-lg ${
+      className={`fixed pt-safe pb-safe ${isHidden ? 'top-0' : 'top-16'} bottom-0 right-0 w-[20.7rem] bg-surface text-foreground flex flex-col transition-all duration-300 ease-in-out z-50 shadow-lg ${
         isOpen ? 'translate-x-0' : 'translate-x-full'
       }`}
     >

--- a/app/shared/navigation/QuranBottomSheet.tsx
+++ b/app/shared/navigation/QuranBottomSheet.tsx
@@ -80,7 +80,7 @@ const QuranBottomSheet: React.FC<QuranBottomSheetProps> = ({ isOpen, onClose, on
               stiffness: 500,
               damping: 40,
             }}
-            className="fixed bottom-0 left-0 right-0 bg-surface rounded-t-3xl shadow-2xl z-50 max-h-[90dvh] flex flex-col touch-pan-y"
+            className="fixed bottom-0 left-0 right-0 bg-surface rounded-t-3xl shadow-2xl z-50 max-h-[90dvh] flex flex-col pb-safe touch-pan-y"
           >
             {/* Handle bar */}
             <div className="flex justify-center pt-4 pb-2">


### PR DESCRIPTION
## Summary
- prevent home indicator overlap in QuranBottomSheet
- add bottom safe padding to settings and word translation panels

## Testing
- `npm run format`
- `npm run lint`
- `npm run check` *(fails: 3 failing test suites)*

------
https://chatgpt.com/codex/tasks/task_b_68a7d3e7a92c832faae33d33004f9c86