### PR TITLE
fix: add bottom safe area to panels

### DIFF
--- a/app/shared/ui/Panel.tsx
+++ b/app/shared/ui/Panel.tsx
@@ -6,10 +6,10 @@ import { CloseIcon } from '@/app/shared/icons';
 import { Button } from './Button';
 
 export const PANEL_VARIANTS = {
-  sidebar: 'fixed top-0 bottom-0 right-0 w-80 bg-surface shadow-lg pt-safe',
+  sidebar: 'fixed top-0 bottom-0 right-0 w-80 bg-surface shadow-lg pt-safe pb-safe',
   modal: 'fixed inset-4 bg-surface rounded-lg shadow-xl max-w-2xl max-h-96 mx-auto my-auto',
   overlay: 'fixed top-16 right-4 w-72 bg-surface rounded-lg shadow-lg border border-border',
-  fullscreen: 'fixed inset-0 bg-surface pt-safe',
+  fullscreen: 'fixed inset-0 bg-surface pt-safe pb-safe',
 } as const;
 
 export interface PanelProps {


### PR DESCRIPTION
## Summary
- add `pb-safe` to Panel sidebar and fullscreen variants to clear device safe areas

## Testing
- `npm run lint`
- `npm run check` *(fails: SettingsSidebar interactions, IndexPage, etc.)*

------
https://chatgpt.com/codex/tasks/task_b_68a7d8e37d20832fb35c3b02cbaa8f0b