### PR TITLE
fix: trigger Quran selector on surah jump

### DIFF
--- a/app/shared/components/AdaptiveLayout.tsx
+++ b/app/shared/components/AdaptiveLayout.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { AnimatePresence, motion } from 'framer-motion';
 import { useResponsiveState } from '@/lib/responsive';
 import { cn } from '@/lib/utils';
+import { useNavigation } from '@/app/providers/NavigationContext';
 import AdaptiveNavigation from './AdaptiveNavigation';
 
 interface AdaptiveLayoutProps {
@@ -26,11 +27,11 @@ const AdaptiveLayout: React.FC<AdaptiveLayoutProps> = ({
   onSidebarToggle,
 }) => {
   const { variant } = useResponsiveState();
+  const { showQuranSelector } = useNavigation();
 
   // Handle navigation visibility
   const handleSurahJump = () => {
-    // Implementation for surah jump functionality
-    console.log('Surah jump triggered');
+    showQuranSelector();
   };
 
   // Adaptive content padding based on navigation presence


### PR DESCRIPTION
## Summary
- call Quran selector when jumping to a surah in AdaptiveLayout

## Testing
- `npm run format`
- `npm run lint`
- `npm run check` *(fails: Test Suites: 7 failed)*

------
https://chatgpt.com/codex/tasks/task_b_68a7d8e61160832fb8407b0f39504c82