### PR TITLE
fix: add safe padding to navigation

### DIFF
--- a/app/shared/Header.tsx
+++ b/app/shared/Header.tsx
@@ -42,7 +42,7 @@ const Header = () => {
     <header
       className={cn(
         'fixed top-0 left-0 right-0 min-h-[calc(3.5rem+env(safe-area-inset-top))] sm:min-h-[calc(4rem+env(safe-area-inset-top))] z-header transition-all duration-300 pt-safe',
-        'flex items-center gap-3 px-3 sm:px-4 lg:px-6',
+        'flex items-center gap-3 pl-safe pr-safe sm:pl-4 sm:pr-4 lg:pl-6 lg:pr-6',
         'border-b backdrop-blur-xl bg-background/80 border-border/10',
         isHidden ? '-translate-y-full' : 'translate-y-0'
       )}

--- a/app/shared/components/AdaptiveNavigation.tsx
+++ b/app/shared/components/AdaptiveNavigation.tsx
@@ -108,7 +108,7 @@ const MobileNavigation: React.FC<{
     <nav className={cn('fixed bottom-0 left-0 right-0 z-50', className)}>
       <div className="absolute inset-0 bg-surface-glass/95 backdrop-blur-xl border-t border-border/20" />
 
-      <div className="relative px-2 pt-2 pb-safe">
+      <div className="relative px-2 pt-2 pb-safe pl-safe pr-safe">
         <div className="flex items-center justify-around">
           {navItems.map((item) => {
             const Icon = item.icon;

--- a/app/shared/navigation/BottomNavigation.tsx
+++ b/app/shared/navigation/BottomNavigation.tsx
@@ -54,7 +54,7 @@ const BottomNavigation: React.FC<BottomNavigationProps> = ({ onSurahJump }) => {
       <div className="absolute inset-0 bg-surface-glass/95 backdrop-blur-xl border-t border-border/20" />
 
       {/* Safe area for iPhone */}
-      <div className="relative px-2 pt-2 pb-safe">
+      <div className="relative px-2 pt-2 pb-safe pl-safe pr-safe">
         <div className="flex items-center justify-around">
           {navItems.map((item) => {
             const Icon = item.icon;

--- a/lib/responsive.ts
+++ b/lib/responsive.ts
@@ -179,8 +179,10 @@ export const layoutPatterns = {
 
   // Header that adapts without breaking
   adaptiveHeader: {
-    mobile: 'fixed top-0 left-0 right-0 min-h-[calc(3.5rem+env(safe-area-inset-top))] px-3 pt-safe',
-    tablet: 'fixed top-0 left-0 right-0 min-h-[calc(4rem+env(safe-area-inset-top))] px-4 pt-safe',
+    mobile:
+      'fixed top-0 left-0 right-0 min-h-[calc(3.5rem+env(safe-area-inset-top))] pt-safe pl-safe pr-safe',
+    tablet:
+      'fixed top-0 left-0 right-0 min-h-[calc(4rem+env(safe-area-inset-top))] pt-safe pl-safe pr-safe',
     desktop: 'static h-20 px-6',
   },
 


### PR DESCRIPTION
## Summary
- apply safe-area horizontal padding to Header
- include safe-area padding in bottom navigation wrappers
- update responsive layout pattern for adaptiveHeader

## Testing
- `npm run format`
- `npm run lint`
- `npm run check` *(fails: SettingsSidebar interactions, TafsirVerseCard, SurahPage, JuzPage, IndexPage, Tafsir IndexPage, SearchPage, Verse tests)*
- `npm test` *(fails: multiple tests including Verse.test.tsx)*

------
https://chatgpt.com/codex/tasks/task_b_68a7e1075ed0832fb2e215862adf8c4e