### PR TITLE
fix: avoid tablet content overlap

### DIFF
--- a/lib/responsive.ts
+++ b/lib/responsive.ts
@@ -187,7 +187,7 @@ export const layoutPatterns = {
   // Content area that works with any navigation
   adaptiveContent: {
     mobile: 'pt-14 bottom-nav-space', // Account for fixed header/nav and safe areas
-    tablet: 'pt-16 pb-4',
+    tablet: 'pt-16 bottom-nav-space',
     desktop: 'p-0', // No fixed elements
   },
 };


### PR DESCRIPTION
## Summary
- ensure tablet content avoids bottom nav overlap by using `bottom-nav-space`

## Testing
- `npm install`
- `npm run format`
- `npm run lint`
- `npm run check` *(fails: SettingsSidebar interactions, TafsirVerseCard, SurahPage, JuzPage, IndexPage tests)*

------
https://chatgpt.com/codex/tasks/task_b_68a7e10cee98832f962e117beb7883b9