### PR TITLE
feat: add touch callout utility

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -252,6 +252,9 @@
   .touch-manipulation {
     touch-action: manipulation;
   }
+  .touch-callout-none {
+    -webkit-touch-callout: none;
+  }
 }
 
 @layer utilities {

--- a/app/shared/navigation/SwipeContainer.tsx
+++ b/app/shared/navigation/SwipeContainer.tsx
@@ -54,9 +54,8 @@ const SwipeContainer: React.FC<SwipeContainerProps> = ({ children, className }) 
   return (
     <div
       {...swipeGestures}
-      className={cn('touch-pan-y select-none', className)}
+      className={cn('touch-pan-y select-none touch-callout-none', className)}
       style={{
-        WebkitTouchCallout: 'none', // Disable iOS context menu
         WebkitUserSelect: 'none', // Disable text selection during swipes
       }}
     >


### PR DESCRIPTION
## Summary
- add `touch-callout-none` utility to disable iOS context menu
- use new helper in `SwipeContainer` and drop inline style

## Testing
- `npm install`
- `npm run check` *(fails: Code style issues found in public/workbox-8232f3e4.js)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68a7e11bc778832f9d907b1a6627cd10