### PR TITLE
fix: add safe-area padding to Surah sidebar

### DIFF
--- a/app/shared/SurahListSidebar.tsx
+++ b/app/shared/SurahListSidebar.tsx
@@ -112,7 +112,7 @@ const SurahListSidebar = ({ initialChapters = [] }: Props) => {
 
       {/* Main sidebar container */}
       <aside
-        className={`drawer-panel md:static top-16 md:top-0 bottom-0 left-0 w-72 sm:w-80 md:w-full bg-background text-foreground flex flex-col shadow-modal md:shadow-lg z-modal md:z-10 md:h-full ${
+        className={`drawer-panel pt-safe pb-safe md:static top-16 md:top-0 bottom-0 left-0 w-72 sm:w-80 md:w-full bg-background text-foreground flex flex-col shadow-modal md:shadow-lg z-modal md:z-10 md:h-full ${
           isSurahListOpen ? 'open' : ''
         } md:translate-x-0`}
         style={{


### PR DESCRIPTION
## Summary
- add `pt-safe pb-safe` to Surah sidebar drawer panel

## Testing
- `npm run format`
- `npm run lint`
- `npm run check` *(fails: Unable to find an accessible element with the role "button" and name "Back"; Found multiple elements with the text; network requests)*

------
https://chatgpt.com/codex/tasks/task_b_68a7e7908df4832f801eb5070c46713c