### PR TITLE
fix: remove WebkitUserSelect style

### DIFF
--- a/app/shared/navigation/SwipeContainer.tsx
+++ b/app/shared/navigation/SwipeContainer.tsx
@@ -52,13 +52,7 @@ const SwipeContainer: React.FC<SwipeContainerProps> = ({ children, className }) 
   });
 
   return (
-    <div
-      {...swipeGestures}
-      className={cn('touch-pan-y select-none touch-callout-none', className)}
-      style={{
-        WebkitUserSelect: 'none', // Disable text selection during swipes
-      }}
-    >
+    <div {...swipeGestures} className={cn('touch-pan-y select-none touch-callout-none', className)}>
       {children}
     </div>
   );


### PR DESCRIPTION
## Summary
- remove unnecessary WebkitUserSelect inline style from SwipeContainer

## Testing
- `npm run lint`
- `npm run check` *(fails: 7 failed, 49 passed)*

------
https://chatgpt.com/codex/tasks/task_b_68a7e7961a70832f81be2cefe2cfc8ee