### PR TITLE
fix: add reciter setting to settings schema

### DIFF
--- a/app/providers/__tests__/SettingsContext.test.tsx
+++ b/app/providers/__tests__/SettingsContext.test.tsx
@@ -34,6 +34,7 @@ describe('SettingsContext settings state', () => {
     wordTranslationId: 85,
     showByWords: false,
     tajweed: false,
+    reciterId: 2,
   };
 
   it('defaults to expected values', () => {

--- a/app/providers/settingsStorage.ts
+++ b/app/providers/settingsStorage.ts
@@ -1,4 +1,5 @@
 import { Settings } from '@/types';
+import { RECITERS } from '@/lib/audio/reciters';
 
 export const ARABIC_FONTS = [
   { name: 'KFGQPC Uthman Taha', value: '"KFGQPC-Uthman-Taha", serif', category: 'Uthmani' },
@@ -22,6 +23,7 @@ export const defaultSettings: Settings = {
   wordTranslationId: 85,
   showByWords: false,
   tajweed: false,
+  reciterId: RECITERS[0].id,
 };
 
 const SETTINGS_KEY = 'quranAppSettings';

--- a/app/shared/navigation/BottomNavigation.tsx
+++ b/app/shared/navigation/BottomNavigation.tsx
@@ -57,7 +57,7 @@ const BottomNavigation: React.FC<BottomNavigationProps> = ({ onSurahJump }) => {
       }`}
     >
       {/* Glass effect backdrop */}
-      <div className="absolute inset-0 backdrop-blur-lg bg-white/10 dark:bg-gray-900/10 backdrop-saturate-150 border-t border-white/5 dark:border-white/5" />
+      <div className="absolute inset-0 backdrop-blur-lg bg-surface/10 backdrop-saturate-150 border-t border-border/5" />
 
       {/* Safe area for iPhone */}
       <div className="relative px-2 pt-2 pb-safe pl-safe pr-safe">

--- a/types/settings.ts
+++ b/types/settings.ts
@@ -13,4 +13,6 @@ export interface Settings {
   wordTranslationId: number;
   showByWords: boolean;
   tajweed: boolean;
+  /** Identifier of selected reciter for audio playback. */
+  reciterId: number;
 }


### PR DESCRIPTION
## Summary
- add `reciterId` to `Settings` type and defaults
- use token colors in bottom navigation backdrop
- adjust SettingsContext tests for new default

## Testing
- `npm run lint`
- `npm run check` *(fails: ENETUNREACH fetching translations; multiple elements with same text; missing accessible elements)*

------
https://chatgpt.com/codex/tasks/task_b_68a89ae58ec4832f8fab0aee64bc0f43