### PR TITLE
refactor: use audio context reciter in tafsir page

### DIFF
--- a/app/(features)/tafsir/[surahId]/[ayahId]/page.tsx
+++ b/app/(features)/tafsir/[surahId]/[ayahId]/page.tsx
@@ -7,7 +7,6 @@ import TafsirViewer from './components/TafsirViewer';
 import TafsirAudioPlayer from './components/TafsirAudioPlayer';
 import { useHeaderVisibility } from '@/app/(features)/layout/context/HeaderVisibilityContext';
 import { useAudio } from '@/app/shared/player/context/AudioContext';
-import { useSettings } from '@/app/providers/SettingsContext';
 
 interface TafsirVersePageProps {
   params: Promise<{ surahId: string; ayahId: string }>;
@@ -17,7 +16,6 @@ export default function TafsirVersePage({ params }: TafsirVersePageProps) {
   const { surahId, ayahId } = React.use(params);
   const { isHidden } = useHeaderVisibility();
   const { activeVerse, isPlayerVisible, reciter } = useAudio();
-  const { settings } = useSettings();
   const {
     verse,
     tafsirHtml,


### PR DESCRIPTION
## Summary
- remove SettingsContext usage from tafsir verse page
- use reciter from AudioContext for TafsirAudioPlayer

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot find module '@tabler/icons-react'; multiple tests failing)*
- `npm run type-check` *(fails: Cannot find module '@tabler/icons-react')*
- `npm run format:check`


------
https://chatgpt.com/codex/tasks/task_b_68a89efcca98832fa2c9a95c681fd3bf