### PR TITLE
feat: trigger section change before nav

### DIFF
--- a/app/shared/ui/cards/BookmarkNavigationCard.tsx
+++ b/app/shared/ui/cards/BookmarkNavigationCard.tsx
@@ -44,9 +44,16 @@ export const BookmarkNavigationCard: React.FC<BookmarkNavigationCardProps> = ({
   onSectionChange,
   isActive = false,
   className,
+  onClick,
   ...props
 }) => {
   const { id, icon: IconComponent, label, description } = content;
+
+  const handleClick: React.MouseEventHandler<HTMLAnchorElement | HTMLDivElement> = (e) => {
+    // Trigger section change before navigation for immediate feedback
+    onSectionChange?.(id);
+    onClick?.(e);
+  };
 
   return (
     <BaseCard
@@ -56,6 +63,7 @@ export const BookmarkNavigationCard: React.FC<BookmarkNavigationCardProps> = ({
       href={getSectionHref(id)}
       scroll={false}
       className={cn('items-center', className)}
+      onClick={handleClick}
       {...props}
     >
       {/* Icon Badge */}


### PR DESCRIPTION
## Summary
- call `onSectionChange` before navigation in `BookmarkNavigationCard` for immediate feedback

## Testing
- `npm run lint -- --file app/shared/ui/cards/BookmarkNavigationCard.tsx`
- `npm test` *(fails: useBookmarks must be used within BookmarkProvider, useUIState must be used within UIStateProvider, etc.)*

------
https://chatgpt.com/codex/tasks/task_b_68adf04d2424832f98441f2d07ef92f6