### PR TITLE
refactor: simplify bookmark routes

### DIFF
--- a/app/shared/ui/cards/BookmarkNavigationCard.tsx
+++ b/app/shared/ui/cards/BookmarkNavigationCard.tsx
@@ -11,6 +11,9 @@ import { cn } from '@/lib/utils/cn';
  * that maintains the current design while using the unified BaseCard system.
  */
 
+// Valid bookmark section identifiers
+type SectionId = 'bookmarks' | 'pinned' | 'last-read' | 'memorization';
+
 interface BookmarkNavigationContent {
   id: string;
   icon: React.ComponentType<{ size?: number; className?: string }>;
@@ -24,20 +27,15 @@ interface BookmarkNavigationCardProps extends Omit<BaseCardProps, 'children'> {
 }
 
 // Map section IDs to URLs for smooth navigation
-const getSectionHref = (sectionId: string): string => {
-  switch (sectionId) {
-    case 'bookmarks':
-      return '/bookmarks';
-    case 'pinned':
-      return '/bookmarks/pinned';
-    case 'last-read':
-      return '/bookmarks/last-read';
-    case 'memorization':
-      return '/bookmarks/memorization';
-    default:
-      return '/bookmarks';
-  }
+const routes: Record<SectionId, string> = {
+  bookmarks: '/bookmarks',
+  pinned: '/bookmarks/pinned',
+  'last-read': '/bookmarks/last-read',
+  memorization: '/bookmarks/memorization',
 };
+
+const getSectionHref = (sectionId: string): string =>
+  routes[sectionId as SectionId] || '/bookmarks';
 
 export const BookmarkNavigationCard: React.FC<BookmarkNavigationCardProps> = ({
   content,


### PR DESCRIPTION
## Summary
- replace switch with route mapping for bookmark navigation
- add `SectionId` union for bookmark sections

## Testing
- `npm run lint` *(fails: Avoid using raw color utility "text-gray-800"...)*
- `npx eslint app/shared/ui/cards/BookmarkNavigationCard.tsx`
- `npm run type-check` *(fails: TS2554, TS2322...)*
- `npm test app/shared/ui/cards/BookmarkNavigationCard.tsx` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_b_68adf0fa6778832f9a4f4851ebfcd951