### PR TITLE
test: add navigation card tests

### DIFF
--- a/app/shared/ui/cards/__tests__/BookmarkNavigationCard.test.tsx
+++ b/app/shared/ui/cards/__tests__/BookmarkNavigationCard.test.tsx
@@ -1,0 +1,69 @@
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders, screen } from '@/app/testUtils/renderWithProviders';
+import { BookmarkNavigationCard } from '../BookmarkNavigationCard';
+
+jest.mock('next/link', () => {
+  return ({ children, href, onClick, ...props }: any) => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { scroll, ...rest } = props;
+    return (
+      <a
+        href={href}
+        onClick={(e) => {
+          e.preventDefault();
+          onClick?.(e);
+        }}
+        {...rest}
+      >
+        {children}
+      </a>
+    );
+  };
+});
+
+const DummyIcon = ({ size = 16, className = '' }: { size?: number; className?: string }) => (
+  <svg data-testid="icon" width={size} height={size} className={className} />
+);
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: jest.fn().mockImplementation((query) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  });
+});
+
+describe('BookmarkNavigationCard', () => {
+  const content = {
+    id: 'bookmarks',
+    icon: DummyIcon,
+    label: 'Bookmarks',
+    description: 'All bookmarks',
+  };
+
+  it('calls onSectionChange when clicked', async () => {
+    const handleSectionChange = jest.fn();
+    renderWithProviders(
+      <BookmarkNavigationCard content={content} onSectionChange={handleSectionChange} />
+    );
+
+    await userEvent.click(screen.getByText('Bookmarks'));
+    expect(handleSectionChange).toHaveBeenCalledWith('bookmarks');
+  });
+
+  it('applies active styling', () => {
+    const { container } = renderWithProviders(
+      <BookmarkNavigationCard content={content} isActive />
+    );
+
+    expect(container.firstChild).toHaveClass('bg-accent');
+  });
+});

--- a/app/shared/ui/cards/__tests__/StandardNavigationCard.test.tsx
+++ b/app/shared/ui/cards/__tests__/StandardNavigationCard.test.tsx
@@ -1,0 +1,43 @@
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders, screen } from '@/app/testUtils/renderWithProviders';
+import { StandardNavigationCard } from '../StandardNavigationCard';
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: jest.fn().mockImplementation((query) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  });
+});
+
+describe('StandardNavigationCard', () => {
+  const content = {
+    id: 1,
+    title: 'Al-Fatihah',
+    subtitle: 'The Opening',
+  };
+
+  it('calls onNavigate when clicked', async () => {
+    const handleNavigate = jest.fn();
+    renderWithProviders(<StandardNavigationCard content={content} onNavigate={handleNavigate} />);
+
+    await userEvent.click(screen.getByText('Al-Fatihah'));
+    expect(handleNavigate).toHaveBeenCalledWith(1);
+  });
+
+  it('applies active styling', () => {
+    const { container } = renderWithProviders(
+      <StandardNavigationCard content={content} isActive />
+    );
+
+    expect(container.firstChild).toHaveClass('bg-accent');
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for StandardNavigationCard and BookmarkNavigationCard
- verify navigation callbacks trigger and active styling applies

## Testing
- `npm run lint` *(fails: Avoid using raw color utility "text-gray-800"...)*
- `npm test app/shared/ui/cards/__tests__/StandardNavigationCard.test.tsx app/shared/ui/cards/__tests__/BookmarkNavigationCard.test.tsx`


------
https://chatgpt.com/codex/tasks/task_b_68adf68a54d8832f83ab069f160abcb1