### PR TITLE
refactor: use numeric ids for sidebar selection

### DIFF
--- a/app/shared/components/SurahListContent.tsx
+++ b/app/shared/components/SurahListContent.tsx
@@ -31,9 +31,21 @@ export const SurahListContent: React.FC<SurahListContentProps> = ({ chapters }) 
 
   const { surahId, juzId, pageId } = useParams();
   const pathname = usePathname();
-  const currentSurahId = Array.isArray(surahId) ? surahId[0] : (surahId as string | undefined);
-  const currentJuzId = Array.isArray(juzId) ? juzId[0] : (juzId as string | undefined);
-  const currentPageId = Array.isArray(pageId) ? pageId[0] : (pageId as string | undefined);
+  const currentSurahId = Array.isArray(surahId)
+    ? Number(surahId[0])
+    : surahId
+      ? Number(surahId)
+      : undefined;
+  const currentJuzId = Array.isArray(juzId)
+    ? Number(juzId[0])
+    : juzId
+      ? Number(juzId)
+      : undefined;
+  const currentPageId = Array.isArray(pageId)
+    ? Number(pageId[0])
+    : pageId
+      ? Number(pageId)
+      : undefined;
 
   const [activeTab, setActiveTab] = useState<'Surah' | 'Juz' | 'Page'>(() => {
     if (currentJuzId) return 'Juz';

--- a/app/shared/surah-sidebar/Juz.tsx
+++ b/app/shared/surah-sidebar/Juz.tsx
@@ -11,10 +11,10 @@ interface JuzSummary {
 interface Props {
   juzs: JuzSummary[];
   chapters: Chapter[];
-  selectedJuzId: string | null;
-  setSelectedJuzId: (id: string) => void;
-  setSelectedPageId: (id: string) => void;
-  setSelectedSurahId: (id: string) => void;
+  selectedJuzId: number | null;
+  setSelectedJuzId: (id: number) => void;
+  setSelectedPageId: (id: number) => void;
+  setSelectedSurahId: (id: number) => void;
   rememberScroll: () => void;
 }
 
@@ -29,7 +29,7 @@ const Juz = ({
 }: Props) => (
   <ul className="space-y-2">
     {juzs.map((juz) => {
-      const isActive = String(juz.number) === selectedJuzId;
+      const isActive = juz.number === selectedJuzId;
       return (
         <li key={juz.number}>
           <JuzNavigationCard
@@ -43,11 +43,11 @@ const Juz = ({
               subtitle: juz.surahRange,
             }}
             onNavigate={() => {
-              setSelectedJuzId(String(juz.number));
+              setSelectedJuzId(juz.number);
               const page = JUZ_START_PAGES[juz.number - 1];
-              setSelectedPageId(String(page));
+              setSelectedPageId(page);
               const chap = getSurahByPage(page, chapters);
-              if (chap) setSelectedSurahId(String(chap.id));
+              if (chap) setSelectedSurahId(chap.id);
               rememberScroll();
             }}
           />

--- a/app/shared/surah-sidebar/Page.tsx
+++ b/app/shared/surah-sidebar/Page.tsx
@@ -5,10 +5,10 @@ import { PageNavigationCard } from '@/app/shared/ui/cards/StandardNavigationCard
 interface Props {
   pages: number[];
   chapters: Chapter[];
-  selectedPageId: string | null;
-  setSelectedPageId: (id: string) => void;
-  setSelectedJuzId: (id: string) => void;
-  setSelectedSurahId: (id: string) => void;
+  selectedPageId: number | null;
+  setSelectedPageId: (id: number) => void;
+  setSelectedJuzId: (id: number) => void;
+  setSelectedSurahId: (id: number) => void;
   rememberScroll: () => void;
 }
 
@@ -23,7 +23,7 @@ const Page = ({
 }: Props) => (
   <ul className="space-y-2">
     {pages.map((p) => {
-      const isActive = String(p) === selectedPageId;
+      const isActive = p === selectedPageId;
       return (
         <li key={p}>
           <PageNavigationCard
@@ -36,10 +36,10 @@ const Page = ({
               title: `Page ${p}`,
             }}
             onNavigate={() => {
-              setSelectedPageId(String(p));
-              setSelectedJuzId(String(getJuzByPage(p)));
+              setSelectedPageId(p);
+              setSelectedJuzId(getJuzByPage(p));
               const chap = getSurahByPage(p, chapters);
-              if (chap) setSelectedSurahId(String(chap.id));
+              if (chap) setSelectedSurahId(chap.id);
               rememberScroll();
             }}
           />

--- a/app/shared/surah-sidebar/Surah.tsx
+++ b/app/shared/surah-sidebar/Surah.tsx
@@ -4,10 +4,10 @@ import { SurahNavigationCard } from '@/app/shared/ui/cards/StandardNavigationCar
 
 interface Props {
   chapters: Chapter[];
-  selectedSurahId: string | null;
-  setSelectedSurahId: (id: string) => void;
-  setSelectedPageId: (id: string) => void;
-  setSelectedJuzId: (id: string) => void;
+  selectedSurahId: number | null;
+  setSelectedSurahId: (id: number) => void;
+  setSelectedPageId: (id: number) => void;
+  setSelectedJuzId: (id: number) => void;
   rememberScroll: () => void;
   isTafsirPath: boolean;
 }
@@ -23,7 +23,7 @@ const Surah = ({
 }: Props) => (
   <ul className="space-y-2">
     {chapters.map((chapter) => {
-      const isActive = String(chapter.id) === selectedSurahId;
+      const isActive = chapter.id === selectedSurahId;
       return (
         <li key={chapter.id}>
           <SurahNavigationCard
@@ -38,10 +38,10 @@ const Surah = ({
               arabic: chapter.name_arabic,
             }}
             onNavigate={() => {
-              setSelectedSurahId(String(chapter.id));
+              setSelectedSurahId(chapter.id);
               const firstPage = chapter.pages?.[0] ?? 1;
-              setSelectedPageId(String(firstPage));
-              setSelectedJuzId(String(getJuzByPage(firstPage)));
+              setSelectedPageId(firstPage);
+              setSelectedJuzId(getJuzByPage(firstPage));
               rememberScroll();
             }}
           />

--- a/app/shared/surah-sidebar/hooks/useSelectionSync.ts
+++ b/app/shared/surah-sidebar/hooks/useSelectionSync.ts
@@ -3,36 +3,36 @@ import { getJuzByPage, getSurahByPage, JUZ_START_PAGES } from '@/lib/utils/surah
 import type { Chapter } from '@/types';
 
 interface Args {
-  currentSurahId?: string;
-  currentJuzId?: string;
-  currentPageId?: string;
+  currentSurahId?: number;
+  currentJuzId?: number;
+  currentPageId?: number;
   chapters: Chapter[];
 }
 
 const useSelectionSync = ({ currentSurahId, currentJuzId, currentPageId, chapters }: Args) => {
-  const [selectedSurahId, setSelectedSurahId] = useState<string | null>(currentSurahId ?? null);
-  const [selectedJuzId, setSelectedJuzId] = useState<string | null>(currentJuzId ?? null);
-  const [selectedPageId, setSelectedPageId] = useState<string | null>(currentPageId ?? null);
+  const [selectedSurahId, setSelectedSurahId] = useState<number | null>(currentSurahId ?? null);
+  const [selectedJuzId, setSelectedJuzId] = useState<number | null>(currentJuzId ?? null);
+  const [selectedPageId, setSelectedPageId] = useState<number | null>(currentPageId ?? null);
 
   useEffect(() => {
     if (currentSurahId) {
       setSelectedSurahId(currentSurahId);
-      const chapter = chapters.find((c) => c.id === Number(currentSurahId));
+      const chapter = chapters.find((c) => c.id === currentSurahId);
       const page = chapter?.pages?.[0] ?? 1;
-      setSelectedPageId(String(page));
-      setSelectedJuzId(String(getJuzByPage(page)));
+      setSelectedPageId(page);
+      setSelectedJuzId(getJuzByPage(page));
     } else if (currentJuzId) {
       setSelectedJuzId(currentJuzId);
-      const page = JUZ_START_PAGES[Number(currentJuzId) - 1];
-      setSelectedPageId(String(page));
+      const page = JUZ_START_PAGES[currentJuzId - 1];
+      setSelectedPageId(page);
       const chapter = getSurahByPage(page, chapters);
-      if (chapter) setSelectedSurahId(String(chapter.id));
+      if (chapter) setSelectedSurahId(chapter.id);
     } else if (currentPageId) {
       setSelectedPageId(currentPageId);
-      const page = Number(currentPageId);
-      setSelectedJuzId(String(getJuzByPage(page)));
+      const page = currentPageId;
+      setSelectedJuzId(getJuzByPage(page));
       const chapter = getSurahByPage(page, chapters);
-      if (chapter) setSelectedSurahId(String(chapter.id));
+      if (chapter) setSelectedSurahId(chapter.id);
     }
   }, [currentSurahId, currentJuzId, currentPageId, chapters]);
 

--- a/app/shared/surah-sidebar/useSidebarScroll.ts
+++ b/app/shared/surah-sidebar/useSidebarScroll.ts
@@ -7,9 +7,9 @@ type TabKey = 'Surah' | 'Juz' | 'Page';
 
 interface Options {
   activeTab: TabKey;
-  selectedSurahId: string | null;
-  selectedJuzId: string | null;
-  selectedPageId: string | null;
+  selectedSurahId: number | null;
+  selectedJuzId: number | null;
+  selectedPageId: number | null;
 }
 
 const useSidebarScroll = ({

--- a/lib/hooks/__tests__/useScrollCentering.test.ts
+++ b/lib/hooks/__tests__/useScrollCentering.test.ts
@@ -39,7 +39,7 @@ describe('useScrollCentering', () => {
       useScrollCentering<Tab>({
         scrollRef,
         activeTab: 'Surah',
-        selectedIds: { Surah: '1', Juz: null, Page: null },
+        selectedIds: { Surah: 1, Juz: null, Page: null },
         scrollTops: { Surah: 0, Juz: 0, Page: 0 },
       })
     );
@@ -53,7 +53,7 @@ describe('useScrollCentering', () => {
       useScrollCentering<Tab>({
         scrollRef,
         activeTab: 'Surah',
-        selectedIds: { Surah: '1', Juz: null, Page: null },
+        selectedIds: { Surah: 1, Juz: null, Page: null },
         scrollTops: { Surah: 0, Juz: 0, Page: 0 },
       })
     );
@@ -66,7 +66,7 @@ describe('useScrollCentering', () => {
       useScrollCentering<Tab>({
         scrollRef,
         activeTab: 'Surah',
-        selectedIds: { Surah: '1', Juz: null, Page: null },
+        selectedIds: { Surah: 1, Juz: null, Page: null },
         scrollTops: { Surah: 0, Juz: 0, Page: 0 },
       })
     );

--- a/lib/hooks/useScrollCentering.ts
+++ b/lib/hooks/useScrollCentering.ts
@@ -3,7 +3,7 @@ import { RefObject, useEffect, useLayoutEffect, useRef } from 'react';
 interface ScrollCenteringOptions<T extends string> {
   scrollRef: RefObject<HTMLDivElement | null>;
   activeTab: T;
-  selectedIds: Record<T, string | null>;
+  selectedIds: Record<T, number | null>;
   scrollTops: Record<T, number>;
 }
 
@@ -32,8 +32,8 @@ const useScrollCentering = <T extends string>({
     });
   }, [tabs]);
 
-  const prevIds = useRef<Record<T, string | null>>(
-    tabs.reduce((acc, t) => ({ ...acc, [t]: selectedIds[t] }), {} as Record<T, string | null>)
+  const prevIds = useRef<Record<T, number | null>>(
+    tabs.reduce((acc, t) => ({ ...acc, [t]: selectedIds[t] }), {} as Record<T, number | null>)
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- use numeric selection IDs throughout Surah, Juz, and Page sidebar components
- update sidebar hooks and state sync to handle number IDs
- adjust parent SurahListContent and tests for numeric IDs

## Testing
- `npm run lint` *(fails: no output, but command executed)*
- `npm test` *(fails: context/provider test failures)*
- `npm run type-check`

------
https://chatgpt.com/codex/tasks/task_b_68adf950e5f8832f946538a617f1fc9a