### PR TITLE
feat: add service teardown helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,10 @@ Generate a coverage report:
 npm run test:coverage
 ```
 
+### Service Teardown
+
+When running tests or using hot reload, call `destroyServices()` during teardown to reset singletons and clean up listeners.
+
 ### Local Tooling
 
 - `npm run rg -- <pattern> [paths]`: Project-local ripgrep for fast text search. Works even if `rg` isn’t installed system-wide.

--- a/src/application/ServiceContainer.ts
+++ b/src/application/ServiceContainer.ts
@@ -117,17 +117,53 @@ export class ServiceContainer {
 
   // Method to reset all services (useful for testing)
   reset(): void {
+    this._bookmarkService?.destroy?.();
+    this._bookmarkService?.dispose?.();
     this._bookmarkService = null;
+
+    this._settingsService?.destroy?.();
+    this._settingsService?.dispose?.();
     this._settingsService = null;
+
+    this._audioService?.destroy?.();
+    this._audioService?.dispose?.();
     this._audioService = null;
+
+    this._themeService?.destroy?.();
+    this._themeService?.dispose?.();
     this._themeService = null;
+
+    this._bookmarkRepository?.destroy?.();
+    this._bookmarkRepository?.dispose?.();
     this._bookmarkRepository = null;
+
+    this._verseRepository?.destroy?.();
+    this._verseRepository?.dispose?.();
     this._verseRepository = null;
+
+    this._settingsRepository?.destroy?.();
+    this._settingsRepository?.dispose?.();
     this._settingsRepository = null;
+
+    this._audioRepository?.destroy?.();
+    this._audioRepository?.dispose?.();
     this._audioRepository = null;
+
+    this._themeRepository?.destroy?.();
+    this._themeRepository?.dispose?.();
     this._themeRepository = null;
+  }
+
+  // Destroy current instance (useful for hot reloads/tests)
+  static destroy(): void {
+    if (ServiceContainer.instance) {
+      ServiceContainer.instance.reset();
+      ServiceContainer.instance = null;
+    }
   }
 }
 
 // Convenience function to get services
 export const getServices = () => ServiceContainer.getInstance();
+// Helper to destroy and reset services
+export const destroyServices = () => ServiceContainer.destroy();


### PR DESCRIPTION
## Summary
- clean up service and repository singletons before reset
- add `destroyServices` helper for hot reloads and tests
- document service teardown requirement in README

## Testing
- `npm run check` *(fails: Code style issues found in 2 files)*

------
https://chatgpt.com/codex/tasks/task_b_68af93ac2dfc832fbd5e44747eac1adb