### PR TITLE
fix: clean up theme listeners on reset

### DIFF
--- a/src/application/ServiceContainer.ts
+++ b/src/application/ServiceContainer.ts
@@ -117,6 +117,7 @@ export class ServiceContainer {
 
   // Method to reset all services (useful for testing)
   reset(): void {
+    this._themeService?.destroy();
     this._bookmarkService = null;
     this._settingsService = null;
     this._audioService = null;
@@ -131,3 +132,7 @@ export class ServiceContainer {
 
 // Convenience function to get services
 export const getServices = () => ServiceContainer.getInstance();
+
+if ((module as any).hot) {
+  (module as any).hot.dispose(() => ServiceContainer.getInstance().reset());
+}


### PR DESCRIPTION
## Summary
- store system theme change handler and remove on destroy
- reset service container and clean up listeners during HMR

## Testing
- `npm run check` *(fails: Code style issues found in 2 files)*
- `npm install` *(fails: Protocol "https:" not supported. Expected "http:" )*

------
https://chatgpt.com/codex/tasks/task_b_68af93ac2158832f880cb6ca2a568339