### PR TITLE
fix: improve verse loading

### DIFF
--- a/app/(features)/surah/[surahId]/SurahClient.tsx
+++ b/app/(features)/surah/[surahId]/SurahClient.tsx
@@ -19,11 +19,11 @@ export default function SurahClient({ surahId }: SurahClientProps) {
   React.useEffect(() => {
     // Only manipulate body overflow in production or when necessary
     if (process.env.NODE_ENV === 'development') return;
-    
+
     // Set initial body overflow, but allow sidebar context to override
     const originalOverflow = document.body.style.overflow;
     document.body.style.overflow = 'hidden';
-    
+
     return () => {
       // Only restore if body overflow is still 'hidden' (not changed by sidebar)
       if (document.body.style.overflow === 'hidden') {

--- a/app/(features)/surah/hooks/useInfiniteVerseLoader.ts
+++ b/app/(features)/surah/hooks/useInfiniteVerseLoader.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import useSWRInfinite from 'swr/infinite';
 import type { Verse } from '@/types';
 import type { LookupFn } from './useVerseListing';
@@ -36,7 +36,10 @@ export function useInfiniteVerseLoader({
   const verses: Verse[] = useMemo(() => (data ? data.flatMap((d) => d.verses) : []), [data]);
   const totalPages = useMemo(() => (data ? data[data.length - 1]?.totalPages : 1), [data]);
   const isLoading = !data && !error;
-  const isReachingEnd = size >= totalPages;
+  const MAX_PAGES = 50;
+  const isReachingEnd = size >= totalPages || size >= MAX_PAGES;
+  const [needsManualLoad, setNeedsManualLoad] = useState(false);
+  const observerRef = useRef<IntersectionObserver | null>(null);
 
   useEffect(() => {
     if (!loadMoreRef.current || isReachingEnd) return;
@@ -51,7 +54,7 @@ export function useInfiniteVerseLoader({
     let scrollRoot = loadMoreRef.current.parentElement;
     let depth = 0;
     const maxDepth = 10; // Prevent infinite traversal
-    
+
     while (scrollRoot && depth < maxDepth) {
       const style = getComputedStyle(scrollRoot);
       if (style.overflowY === 'auto' || style.overflowY === 'scroll') {
@@ -67,16 +70,30 @@ export function useInfiniteVerseLoader({
     }
 
     const targetElement = loadMoreRef.current;
+
+    const isOutsideViewport = () => {
+      const rect = targetElement.getBoundingClientRect();
+      const viewportBottom = scrollRoot
+        ? (scrollRoot as Element).getBoundingClientRect().bottom
+        : window.innerHeight;
+      return rect.top > viewportBottom;
+    };
+
     const observer = new IntersectionObserver(
       (entries) => {
         const entry = entries[0];
         if (entry && entry.isIntersecting && !isReachingEnd && !isValidating) {
-          // Add debounce to prevent rapid firing
-          setTimeout(() => {
-            if (!isReachingEnd && !isValidating) {
-              setSize(prev => prev + 1);
+          observer.unobserve(targetElement);
+          setSize((prev) => prev + 1).finally(() => {
+            if (loadMoreRef.current && !isReachingEnd) {
+              if (isOutsideViewport()) {
+                setNeedsManualLoad(false);
+                observer.observe(loadMoreRef.current);
+              } else {
+                setNeedsManualLoad(true);
+              }
             }
-          }, 100);
+          });
         }
       },
       {
@@ -86,15 +103,41 @@ export function useInfiniteVerseLoader({
       }
     );
 
-    observer.observe(targetElement);
-    
+    observerRef.current = observer;
+
+    if (isOutsideViewport()) {
+      observer.observe(targetElement);
+    } else {
+      setNeedsManualLoad(true);
+    }
+
     return () => {
-      observer.unobserve(targetElement);
       observer.disconnect();
+      observerRef.current = null;
     };
   }, [isReachingEnd, isValidating, verses.length]); // Removed size dependency to prevent excessive re-renders
 
-  return { verses, isLoading, isValidating, isReachingEnd } as const;
+  const loadMore = () => {
+    if (isReachingEnd || isValidating) return;
+    setNeedsManualLoad(false);
+    setSize((prev) => prev + 1).finally(() => {
+      if (loadMoreRef.current && observerRef.current && !isReachingEnd) {
+        const targetElement = loadMoreRef.current;
+        const rect = targetElement.getBoundingClientRect();
+        const viewportBottom =
+          observerRef.current.root instanceof Element
+            ? observerRef.current.root.getBoundingClientRect().bottom
+            : window.innerHeight;
+        if (rect.top > viewportBottom) {
+          observerRef.current.observe(targetElement);
+        } else {
+          setNeedsManualLoad(true);
+        }
+      }
+    });
+  };
+
+  return { verses, isLoading, isValidating, isReachingEnd, loadMore, needsManualLoad } as const;
 }
 
 export default useInfiniteVerseLoader;


### PR DESCRIPTION
## Summary
- unobserve sentinel before fetching to avoid duplicate page loads
- add hard page limit and manual load fallback if sentinel starts in view
- format SurahClient to satisfy prettier

## Testing
- `npm run check` *(fails: sh: 1: next: not found)*
- `npm install` *(fails: Downloading ripgrep failed: Protocol "https:" not supported)*

------
https://chatgpt.com/codex/tasks/task_b_68af93a78980832f99f5d614899bbb4c