### PR TITLE
docs: add tests guidelines

### DIFF
--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -1,0 +1,7 @@
+# Tests Directory Guidelines
+
+- **Framework**: Use Jest with Testing Library for all unit and integration tests.
+- **Provider Wrappers**: Wrap components using `renderWithProviders` from `app/testUtils/renderWithProviders`, which applies `ThemeProvider`, `SettingsProvider`, `SidebarProvider`, `BookmarkProvider`, `AudioProvider`, and an `SWRConfig` with an isolated cache.
+- **File Naming**: Name test files in PascalCase following the pattern `ComponentName.test.tsx`.
+- **Commands**: Run `npm run test` before committing to verify all tests pass.
+


### PR DESCRIPTION
## Summary
- document testing requirements and naming in tests/AGENTS.md

## Testing
- `npm run test` *(fails: Bus error)*

------
https://chatgpt.com/codex/tasks/task_b_68b493e8013c832fbc280b780af574ff