### PR TITLE
docs: add AI automation tools

### DIFF
--- a/docs/ai/automation-tools.md
+++ b/docs/ai/automation-tools.md
@@ -1,0 +1,32 @@
+# AI Automation Tools
+
+AI scripts live in `tools/ai` and help keep documentation and tests in sync with the codebase.
+
+## doc-updater
+
+- **Purpose:** Automatically updates documentation when code changes are detected to keep docs consistent with the latest code.
+- **When to use:** Run after making code changes that should be reflected in docs, especially before committing.
+- **Sample invocation:**
+  ```bash
+  node tools/ai/doc-updater.js
+  ```
+
+## pre-commit-ai-check
+
+- **Purpose:** Analyzes staged changes and reports issues or suggestions before a commit is created.
+- **When to use:** Run before committing to catch problems early or integrate as a git pre-commit hook.
+- **Sample invocation:**
+  ```bash
+  node tools/ai/pre-commit-ai-check.js
+  ```
+
+## test-generator
+
+- **Purpose:** Creates test file templates based on a target file's type and location.
+- **When to use:** Run after adding new entities, services, components, hooks, or other supported files to scaffold matching tests.
+- **Sample invocation:**
+  ```bash
+  node tools/ai/test-generator.js path/to/file.ts
+  # Example
+  node tools/ai/test-generator.js src/domain/entities/Verse.ts
+  ```

--- a/docs/ai/search-patterns.md
+++ b/docs/ai/search-patterns.md
@@ -1,8 +1,11 @@
 # AI Search Patterns - Efficient Code Discovery
 
+For automated doc maintenance and testing aids, see [AI Automation Tools](automation-tools.md).
+
 ## Quick Reference Commands
 
 ### Component Discovery
+
 ```bash
 # Find all React components
 Grep "export.*React.FC" --glob "**/*.tsx"
@@ -21,6 +24,7 @@ Glob "app/shared/**/*.tsx"
 ```
 
 ### Domain Layer Search
+
 ```bash
 # Find all domain entities
 Glob "src/domain/entities/**/*.ts"
@@ -37,6 +41,7 @@ Glob "src/domain/value-objects/**/*.ts"
 ```
 
 ### Business Logic Discovery
+
 ```bash
 # Find all use cases
 Glob "src/application/use-cases/**/*.ts"
@@ -53,6 +58,7 @@ Grep "throw.*Error" src/domain/ --glob "*.ts"
 ```
 
 ### Infrastructure Search
+
 ```bash
 # Find API clients
 Glob "src/infrastructure/api/**/*.ts"
@@ -67,6 +73,7 @@ Glob "src/infrastructure/external/**/*.ts"
 ```
 
 ### Hook and State Search
+
 ```bash
 # Find custom hooks
 Grep "export.*use[A-Z]" --glob "**/*.ts" --glob "**/*.tsx"
@@ -82,6 +89,7 @@ Grep "useSWR\|mutate" --glob "**/*.tsx"
 ```
 
 ### Testing Discovery
+
 ```bash
 # Find all test files
 Glob "**/*.test.ts*"
@@ -102,6 +110,7 @@ Glob "tests/e2e/**/*.test.ts"
 ## Advanced Search Patterns
 
 ### Feature-Specific Searches
+
 ```bash
 # All files related to bookmarks feature
 Grep -i "bookmark" --glob "**/*.ts*" app/
@@ -117,6 +126,7 @@ Grep -i "surah\|verse" --glob "**/*.ts*" app/(features)/
 ```
 
 ### Type and Interface Discovery
+
 ```bash
 # Find type definitions
 Grep "type.*=" types/ --glob "*.ts"
@@ -130,6 +140,7 @@ Grep "type.*=.*\|" types/ --glob "*.ts"
 ```
 
 ### Configuration and Setup
+
 ```bash
 # Find configuration files
 Glob "**/config/**/*"
@@ -145,6 +156,7 @@ Grep "container\|inject\|bind" src/shared/config/
 ## Search by Functionality
 
 ### Data Fetching Patterns
+
 ```bash
 # API calls and data fetching
 Grep "fetch\|axios\|useSWR" --glob "**/*.ts*"
@@ -157,6 +169,7 @@ Grep "cache\|Cache" --glob "**/*.ts*"
 ```
 
 ### Error Handling Patterns
+
 ```bash
 # Error definitions
 Grep "extends.*Error\|Error.*class" --glob "**/*.ts"
@@ -169,6 +182,7 @@ Grep "ErrorBoundary\|componentDidCatch" --glob "**/*.tsx"
 ```
 
 ### Performance Patterns
+
 ```bash
 # Memoization usage
 Grep "useMemo\|useCallback\|React\.memo" --glob "**/*.tsx"
@@ -181,6 +195,7 @@ Grep "lazy\|Suspense" --glob "**/*.tsx"
 ```
 
 ### Accessibility Patterns
+
 ```bash
 # ARIA attributes
 Grep "aria-\|role=" --glob "**/*.tsx"
@@ -195,6 +210,7 @@ Grep "focus\|tabindex" --glob "**/*.tsx"
 ## Problem-Specific Search Strategies
 
 ### Debugging Component Issues
+
 ```bash
 # 1. Find the component
 Glob "**/*ComponentName*.*"
@@ -210,6 +226,7 @@ Glob "**/*ComponentName*.test.*"
 ```
 
 ### Understanding Data Flow
+
 ```bash
 # 1. Start with the entity
 Grep "class.*EntityName" src/domain/entities/
@@ -225,6 +242,7 @@ Grep "EntityName" --glob "**/*.tsx"
 ```
 
 ### Performance Investigation
+
 ```bash
 # 1. Find expensive operations
 Grep "map\|filter\|reduce.*\(" --glob "**/*.tsx" -A 3
@@ -239,18 +257,21 @@ Grep "useEffect.*\[\]" --glob "**/*.tsx"
 ## Context-Aware Search Tips
 
 ### Before Making Changes
+
 1. **Search existing patterns**: Look for similar implementations
 2. **Check dependencies**: Find what uses the code you're changing
 3. **Review tests**: Understand expected behavior
 4. **Check types**: Ensure TypeScript compatibility
 
 ### Search Workflow for New Features
+
 1. **Find similar features**: `Grep -i "similar-feature" --glob "**/*.ts*"`
 2. **Check domain layer**: `Glob "src/domain/**/*Similar*.*"`
 3. **Review architecture**: `Grep "Similar.*Service\|Similar.*UseCase"`
 4. **Study UI patterns**: `Grep "Similar" app/ --glob "*.tsx"`
 
 ### Multi-Step Discovery Process
+
 ```bash
 # Step 1: Broad search for concept
 Grep -i "concept" --glob "**/*.ts*" | head -20
@@ -268,16 +289,19 @@ Grep "concept" --glob "**/*.tsx" -B 2 -A 2
 ## AI Efficiency Guidelines
 
 ### Search Before Creating
+
 - Always search for existing implementations before building new ones
 - Use multiple search patterns to ensure comprehensive discovery
 - Check both current and legacy code paths
 
 ### Understand Context
+
 - Search for usage patterns to understand how code should integrate
 - Find tests to understand expected behavior
 - Check dependencies to avoid breaking changes
 
 ### Follow Architecture
+
 - Start searches in the appropriate layer (domain, application, presentation)
 - Follow dependency direction (presentation → application → domain → infrastructure)
 - Respect clean architecture boundaries in implementations


### PR DESCRIPTION
## Summary
- document doc-updater, pre-commit-ai-check, and test-generator usage
- link automation tools from AI search patterns for discoverability

## Testing
- `npm run check` *(fails: Code style issues found in 11 files)*
- `npm run lint -- docs/ai/automation-tools.md docs/ai/search-patterns.md` *(fails: next not found)*
- `npm install` *(fails: Downloading ripgrep failed; Protocol "https:" not supported)*

------
https://chatgpt.com/codex/tasks/task_b_68b495c1242c832f91f508a2dea6e0de