### PR TITLE
chore: add complexity and console lint rules

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -56,6 +56,7 @@ const eslintConfig = [
           IIFEs: true,
         },
       ],
+      'max-statements': ['warn', 30],
       complexity: ['warn', 10],
       'max-params': ['warn', 4],
       'max-depth': ['warn', 3],
@@ -97,6 +98,8 @@ const eslintConfig = [
       // React best practices
       'react/display-name': 'off', // Using memo properly
       'react-hooks/exhaustive-deps': 'warn',
+      // Console usage
+      'no-console': ['warn', { allow: ['warn', 'error'] }],
     },
     settings: {
       'import/resolver': {


### PR DESCRIPTION
## Summary
- warn when functions exceed 30 statements
- warn on console usage except `warn` and `error`

## Testing
- `npm run check` *(fails: @typescript-eslint/no-explicit-any errors in src/infrastructure/errors/factory.ts)*

------
https://chatgpt.com/codex/tasks/task_b_68bbe22ab330832f822b13ef6e90e831