### PR TITLE
test: split Surah metrics cases

### DIFF
--- a/tests/unit/domain/entities/Surah.difficulty.test.ts
+++ b/tests/unit/domain/entities/Surah.difficulty.test.ts
@@ -1,0 +1,35 @@
+import { getEstimatedReadingTime, getMemorizationDifficulty } from '../../../../src/domain/entities';
+import { createSurah } from './Surah/test-utils';
+
+describe('Surah difficulty utilities', () => {
+  describe('getMemorizationDifficulty', () => {
+    it('returns "easy" for 10 or fewer verses', () => {
+      const surah = createSurah({ numberOfAyahs: 4 });
+      expect(getMemorizationDifficulty(surah.numberOfAyahs)).toBe('easy');
+    });
+
+    it('returns "medium" for 11-50 verses', () => {
+      const surah = createSurah({ id: 36, numberOfAyahs: 25 });
+      expect(getMemorizationDifficulty(surah.numberOfAyahs)).toBe('medium');
+    });
+
+    it('returns "hard" for more than 50 verses', () => {
+      const surah = createSurah({ id: 18, numberOfAyahs: 110 });
+      expect(getMemorizationDifficulty(surah.numberOfAyahs)).toBe('hard');
+    });
+  });
+
+  describe('getEstimatedReadingTime', () => {
+    it('calculates reading time based on number of ayahs', () => {
+      const surah = createSurah({ numberOfAyahs: 7 });
+      const readingTime = getEstimatedReadingTime(surah.numberOfAyahs);
+      expect(readingTime).toBe(1);
+    });
+
+    it('returns reasonable time for long Surah', () => {
+      const surah = createSurah({ id: 2, numberOfAyahs: 286 });
+      const readingTime = getEstimatedReadingTime(surah.numberOfAyahs);
+      expect(readingTime).toBe(29);
+    });
+  });
+});

--- a/tests/unit/domain/entities/Surah.length.test.ts
+++ b/tests/unit/domain/entities/Surah.length.test.ts
@@ -1,0 +1,32 @@
+import { isLongSurah, isMediumSurah, isShortSurah } from '../../../../src/domain/entities';
+import { createSurah, RevelationType } from './Surah/test-utils';
+
+describe('Surah length classification', () => {
+  it('classifies short Surah', () => {
+    const surah = createSurah({ id: 108, numberOfAyahs: 3 });
+    expect(isShortSurah(surah.numberOfAyahs)).toBe(true);
+    expect(isMediumSurah(surah.numberOfAyahs)).toBe(false);
+    expect(isLongSurah(surah.numberOfAyahs)).toBe(false);
+  });
+
+  it('classifies medium Surah within range', () => {
+    const surah = createSurah({ id: 50, numberOfAyahs: 50 });
+    expect(isShortSurah(surah.numberOfAyahs)).toBe(false);
+    expect(isMediumSurah(surah.numberOfAyahs)).toBe(true);
+    expect(isLongSurah(surah.numberOfAyahs)).toBe(false);
+  });
+
+  it('classifies medium Surah at boundary of 20 verses', () => {
+    const surah = createSurah({ id: 20, numberOfAyahs: 20 });
+    expect(isShortSurah(surah.numberOfAyahs)).toBe(false);
+    expect(isMediumSurah(surah.numberOfAyahs)).toBe(true);
+    expect(isLongSurah(surah.numberOfAyahs)).toBe(false);
+  });
+
+  it('classifies long Surah', () => {
+    const surah = createSurah({ id: 2, numberOfAyahs: 286, revelationType: RevelationType.MADANI });
+    expect(isShortSurah(surah.numberOfAyahs)).toBe(false);
+    expect(isMediumSurah(surah.numberOfAyahs)).toBe(false);
+    expect(isLongSurah(surah.numberOfAyahs)).toBe(true);
+  });
+});

--- a/tests/unit/domain/entities/Surah.metrics.test.ts
+++ b/tests/unit/domain/entities/Surah.metrics.test.ts
@@ -1,14 +1,9 @@
 import {
   Surah,
   RevelationType,
-  getEstimatedReadingTime,
   getJuzNumbers,
-  getMemorizationDifficulty,
-  isLongSurah,
-  isMediumSurah,
   isMufassalSurah,
   isSevenLongSurah,
-  isShortSurah,
 } from '../../../../src/domain/entities';
 
 describe('Surah Entity - Metrics', () => {
@@ -52,135 +47,6 @@ describe('Surah Entity - Metrics', () => {
     });
   });
 
-  describe('length classification', () => {
-    it('should classify short Surah correctly (less than 20 verses)', () => {
-      const shortSurah = new Surah(
-        108,
-        'الكوثر',
-        'الكوثر',
-        'Al-Kawthar',
-        'The Abundance',
-        3,
-        RevelationType.MAKKI
-      );
-
-      expect(isShortSurah(shortSurah.numberOfAyahs)).toBe(true);
-      expect(isMediumSurah(shortSurah.numberOfAyahs)).toBe(false);
-      expect(isLongSurah(shortSurah.numberOfAyahs)).toBe(false);
-    });
-
-    it('should classify medium Surah correctly (20-100 verses)', () => {
-      const mediumSurah = new Surah(
-        12,
-        'يوسف',
-        'يوسف',
-        'Yusuf',
-        'Joseph',
-        111,
-        RevelationType.MAKKI
-      );
-
-      expect(isShortSurah(mediumSurah.numberOfAyahs)).toBe(false);
-      expect(isMediumSurah(mediumSurah.numberOfAyahs)).toBe(false); // 111 > 100, so it's long
-      expect(isLongSurah(mediumSurah.numberOfAyahs)).toBe(true);
-    });
-
-    it('should classify medium Surah correctly (exactly 20 verses)', () => {
-      const mediumSurah = new Surah(20, 'طه', 'طه', 'Ta-Ha', 'Ta-Ha', 20, RevelationType.MAKKI);
-
-      expect(isShortSurah(mediumSurah.numberOfAyahs)).toBe(false);
-      expect(isMediumSurah(mediumSurah.numberOfAyahs)).toBe(true);
-      expect(isLongSurah(mediumSurah.numberOfAyahs)).toBe(false);
-    });
-
-    it('should classify long Surah correctly (more than 100 verses)', () => {
-      const longSurah = new Surah(
-        2,
-        'البقرة',
-        'البقرة',
-        'Al-Baqarah',
-        'The Cow',
-        286,
-        RevelationType.MADANI
-      );
-
-      expect(isShortSurah(longSurah.numberOfAyahs)).toBe(false);
-      expect(isMediumSurah(longSurah.numberOfAyahs)).toBe(false);
-      expect(isLongSurah(longSurah.numberOfAyahs)).toBe(true);
-    });
-  });
-
-  describe('getMemorizationDifficulty', () => {
-    it('should return "easy" for Surahs with 10 or fewer verses', () => {
-      const easySurah = new Surah(
-        112,
-        'الإخلاص',
-        'الإخلاص',
-        'Al-Ikhlas',
-        'The Sincerity',
-        4,
-        RevelationType.MAKKI
-      );
-
-      expect(getMemorizationDifficulty(easySurah.numberOfAyahs)).toBe('easy');
-    });
-
-    it('should return "medium" for Surahs with 11-50 verses', () => {
-      const mediumSurah = new Surah(36, 'يس', 'يس', 'Ya-Sin', 'Ya-Sin', 25, RevelationType.MAKKI);
-
-      expect(getMemorizationDifficulty(mediumSurah.numberOfAyahs)).toBe('medium');
-    });
-
-    it('should return "hard" for Surahs with more than 50 verses', () => {
-      const hardSurah = new Surah(
-        18,
-        'الكهف',
-        'الكهف',
-        'Al-Kahf',
-        'The Cave',
-        110,
-        RevelationType.MAKKI
-      );
-
-      expect(getMemorizationDifficulty(hardSurah.numberOfAyahs)).toBe('hard');
-    });
-  });
-
-  describe('getEstimatedReadingTime', () => {
-    it('should calculate reading time based on number of ayahs', () => {
-      const surah = new Surah(
-        1,
-        validName,
-        validArabicName,
-        validEnglishName,
-        validEnglishTranslation,
-        7, // 7 verses
-        validRevelationType
-      );
-
-      const readingTime = getEstimatedReadingTime(surah.numberOfAyahs);
-      // 7 verses * 15 words/verse = 105 words
-      // 105 words / 150 words/minute = 0.7 minutes, rounded up to 1
-      expect(readingTime).toBe(1);
-    });
-
-    it('should return reasonable time for long Surah', () => {
-      const longSurah = new Surah(
-        2,
-        'البقرة',
-        'البقرة',
-        'Al-Baqarah',
-        'The Cow',
-        286,
-        RevelationType.MADANI
-      );
-
-      const readingTime = getEstimatedReadingTime(longSurah.numberOfAyahs);
-      // 286 verses * 15 words/verse = 4290 words
-      // 4290 words / 150 words/minute = 28.6 minutes, rounded up to 29
-      expect(readingTime).toBe(29);
-    });
-  });
 
   describe('special Surah classifications', () => {
     it('should correctly identify Seven Long Surahs', () => {

--- a/tests/unit/domain/entities/Surah/test-utils.ts
+++ b/tests/unit/domain/entities/Surah/test-utils.ts
@@ -1,0 +1,36 @@
+import { Surah, RevelationType } from '../../../../src/domain/entities';
+
+interface SurahProps {
+  id: number;
+  name: string;
+  arabicName: string;
+  englishName: string;
+  englishTranslation: string;
+  numberOfAyahs: number;
+  revelationType: RevelationType;
+}
+
+const defaultProps: SurahProps = {
+  id: 1,
+  name: 'الفاتحة',
+  arabicName: 'الفاتحة',
+  englishName: 'Al-Fatiha',
+  englishTranslation: 'The Opening',
+  numberOfAyahs: 7,
+  revelationType: RevelationType.MAKKI,
+};
+
+export function createSurah(overrides: Partial<SurahProps> = {}): Surah {
+  const props = { ...defaultProps, ...overrides };
+  return new Surah(
+    props.id,
+    props.name,
+    props.arabicName,
+    props.englishName,
+    props.englishTranslation,
+    props.numberOfAyahs,
+    props.revelationType
+  );
+}
+
+export { RevelationType };


### PR DESCRIPTION
## Summary
- move Surah length classification checks to dedicated spec
- extract difficulty and reading time helper tests
- share Surah fixtures through reusable test util

## Testing
- `npm test tests/unit/domain/entities/Surah.length.test.ts` *(fails: SyntaxError from node-fetch ESM)*

------
https://chatgpt.com/codex/tasks/task_b_68bd29788ecc832f8c2a8a15b98adfe5