### PR TITLE
refactor: extract navigation and bookmark helpers

### DIFF
--- a/app/providers/bookmarks/BookmarkProvider.tsx
+++ b/app/providers/bookmarks/BookmarkProvider.tsx
@@ -1,85 +1,45 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import { useSettings } from '@/app/providers/SettingsContext';
-import { getChapters } from '@/lib/api/chapters';
-import { getVerseById, getVerseByKey } from '@/lib/api/verses';
-import { Folder, Bookmark, Chapter, MemorizationPlan } from '@/types';
 
-import {
-  findBookmarkInFolders,
-  isVerseBookmarked,
-  getAllBookmarkedVerses,
-  updateBookmarkInFolders,
-} from './bookmark-utils';
+import { findBookmarkInFolders, isVerseBookmarked, getAllBookmarkedVerses } from './bookmark-utils';
 import { BookmarkContext } from './BookmarkContext';
+import { useBookmarkData } from './hooks/useBookmarkData';
+import { useBookmarkMetadata } from './hooks/useBookmarkMetadata';
 import useBookmarkOperations from './hooks/useBookmarkOperations';
 import useFolderOperations from './hooks/useFolderOperations';
 import useMemorizationOperations from './hooks/useMemorizationOperations';
-import {
-  loadBookmarksFromStorage,
-  saveBookmarksToStorage,
-  loadPinnedFromStorage,
-  savePinnedToStorage,
-  loadLastReadFromStorage,
-  saveLastReadToStorage,
-  loadMemorizationFromStorage,
-  saveMemorizationToStorage,
-} from './storage-utils';
-import { BookmarkContextType } from './types';
-export const BookmarkProvider = ({ children }: { children: React.ReactNode }) => {
-  const [folders, setFolders] = useState<Folder[]>([]);
-  const [pinnedVerses, setPinnedVerses] = useState<Bookmark[]>([]);
-  const [lastRead, setLastReadState] = useState<Record<string, number>>({});
-  const [memorization, setMemorizationState] = useState<Record<string, MemorizationPlan>>({});
-  const [chapters, setChapters] = useState<Chapter[]>([]);
+import { usePinnedBookmarks } from './hooks/usePinnedBookmarks';
+
+import type { BookmarkContextType } from './types';
+import type { Bookmark, Folder } from '@/types';
+
+export const BookmarkProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}): React.ReactElement => {
+  const value = useBookmarkProviderValue();
+  return <BookmarkContext.Provider value={value}>{children}</BookmarkContext.Provider>;
+};
+
+function useBookmarkProviderValue(): BookmarkContextType {
+  const {
+    folders,
+    setFolders,
+    pinnedVerses,
+    setPinnedVerses,
+    lastRead,
+    setLastReadState,
+    memorization,
+    setMemorizationState,
+    chapters,
+  } = useBookmarkData();
   const { settings } = useSettings();
 
-  useEffect(() => {
-    void getChapters()
-      .then(setChapters)
-      .catch(() => {});
-    setFolders(loadBookmarksFromStorage());
-    setPinnedVerses(loadPinnedFromStorage());
-    setLastReadState(loadLastReadFromStorage());
-    setMemorizationState(loadMemorizationFromStorage());
-  }, []);
-
-  useEffect(() => saveBookmarksToStorage(folders), [folders]);
-  useEffect(() => savePinnedToStorage(pinnedVerses), [pinnedVerses]);
-  useEffect(() => saveLastReadToStorage(lastRead), [lastRead]);
-  useEffect(() => saveMemorizationToStorage(memorization), [memorization]);
-
-  const fetchBookmarkMetadata = useCallback(
-    async (verseId: string, chaptersList: Chapter[]) => {
-      try {
-        const translationId = settings.translationIds[0] || settings.translationId || 20;
-        const isCompositeKey = /:/.test(verseId) || /[^0-9]/.test(verseId);
-        const verse = await (isCompositeKey
-          ? getVerseByKey(verseId, translationId)
-          : getVerseById(verseId, translationId));
-        const [surahIdStr] = verse.verse_key.split(':');
-        const surahInfo = chaptersList.find((chapter) => chapter.id === parseInt(surahIdStr));
-
-        const metadata = {
-          verseKey: verse.verse_key,
-          verseText: verse.text_uthmani,
-          surahName: surahInfo?.name_simple || `Surah ${surahIdStr}`,
-          translation: verse.translations?.[0]?.text,
-          verseApiId: verse.id,
-        };
-
-        setFolders((prev) => updateBookmarkInFolders(prev, verseId, metadata));
-        setPinnedVerses((prev) =>
-          prev.map((b) => (b.verseId === verseId ? { ...b, ...metadata } : b))
-        );
-      } catch {
-        // Silent fail for metadata fetch errors
-      }
-    },
-    [settings.translationIds, settings.translationId, setFolders, setPinnedVerses]
-  );
+  const fetchBookmarkMetadata = useBookmarkMetadata(settings, setFolders, setPinnedVerses);
 
   const folderOps = useFolderOperations(setFolders);
   const bookmarkOps = useBookmarkOperations(
@@ -91,7 +51,36 @@ export const BookmarkProvider = ({ children }: { children: React.ReactNode }) =>
     fetchBookmarkMetadata
   );
   const memorizationOps = useMemorizationOperations(memorization, setMemorizationState);
+  const helpers = useBookmarkHelpers(folders, pinnedVerses, bookmarkOps, setLastReadState);
 
+  return useMemo(
+    () => ({
+      folders,
+      ...folderOps,
+      ...bookmarkOps,
+      ...helpers,
+      lastRead,
+      chapters,
+      memorization,
+      ...memorizationOps,
+    }),
+    [folders, folderOps, bookmarkOps, helpers, lastRead, chapters, memorization, memorizationOps]
+  );
+}
+
+function useBookmarkHelpers(
+  folders: Folder[],
+  pinnedVerses: Bookmark[],
+  bookmarkOps: ReturnType<typeof useBookmarkOperations>,
+  setLastReadState: ReturnType<typeof useBookmarkData>['setLastReadState']
+): {
+  isBookmarked: (verseId: string) => boolean;
+  findBookmark: (verseId: string) => ReturnType<typeof findBookmarkInFolders>;
+  bookmarkedVerses: string[];
+  togglePinned: (verseId: string) => void;
+  isPinned: (verseId: string) => boolean;
+  setLastRead: (surahId: string, verseId: number) => void;
+} {
   const isBookmarked = useCallback(
     (verseId: string) => isVerseBookmarked(folders, verseId),
     [folders]
@@ -103,44 +92,21 @@ export const BookmarkProvider = ({ children }: { children: React.ReactNode }) =>
   );
 
   const bookmarkedVerses = useMemo(() => getAllBookmarkedVerses(folders), [folders]);
+  const { togglePinned, isPinned } = usePinnedBookmarks(pinnedVerses, bookmarkOps);
 
-  const togglePinned = useCallback(
-    (verseId: string) => {
-      const isPinned = pinnedVerses.some((b) => b.verseId === verseId);
-      if (isPinned) {
-        bookmarkOps.removeBookmark(verseId, 'pinned');
-      } else {
-        bookmarkOps.addBookmark(verseId, 'pinned');
-      }
+  const setLastRead = useCallback(
+    (surahId: string, verseId: number) => {
+      setLastReadState((prev) => ({ ...prev, [surahId]: verseId }));
     },
-    [pinnedVerses, bookmarkOps]
+    [setLastReadState]
   );
 
-  const isPinned = useCallback(
-    (verseId: string) => pinnedVerses.some((b) => b.verseId === verseId),
-    [pinnedVerses]
-  );
-
-  const setLastRead = useCallback((surahId: string, verseId: number) => {
-    setLastReadState((prev) => ({ ...prev, [surahId]: verseId }));
-  }, []);
-
-  const value: BookmarkContextType = {
-    folders,
-    ...folderOps,
-    ...bookmarkOps,
+  return {
     isBookmarked,
     findBookmark,
     bookmarkedVerses,
-    pinnedVerses,
     togglePinned,
     isPinned,
-    lastRead,
     setLastRead,
-    chapters,
-    memorization,
-    ...memorizationOps,
-  };
-
-  return <BookmarkContext.Provider value={value}>{children}</BookmarkContext.Provider>;
-};
+  } as const;
+}

--- a/app/providers/bookmarks/hooks/useBookmarkData.ts
+++ b/app/providers/bookmarks/hooks/useBookmarkData.ts
@@ -1,0 +1,61 @@
+import { useEffect, useState } from 'react';
+
+import { getChapters } from '@/lib/api/chapters';
+
+import {
+  loadBookmarksFromStorage,
+  saveBookmarksToStorage,
+  loadPinnedFromStorage,
+  savePinnedToStorage,
+  loadLastReadFromStorage,
+  saveLastReadToStorage,
+  loadMemorizationFromStorage,
+  saveMemorizationToStorage,
+} from '../storage-utils';
+
+import type { Folder, Bookmark, Chapter, MemorizationPlan } from '@/types';
+
+export function useBookmarkData(): {
+  folders: Folder[];
+  setFolders: React.Dispatch<React.SetStateAction<Folder[]>>;
+  pinnedVerses: Bookmark[];
+  setPinnedVerses: React.Dispatch<React.SetStateAction<Bookmark[]>>;
+  lastRead: Record<string, number>;
+  setLastReadState: React.Dispatch<React.SetStateAction<Record<string, number>>>;
+  memorization: Record<string, MemorizationPlan>;
+  setMemorizationState: React.Dispatch<React.SetStateAction<Record<string, MemorizationPlan>>>;
+  chapters: Chapter[];
+} {
+  const [folders, setFolders] = useState<Folder[]>([]);
+  const [pinnedVerses, setPinnedVerses] = useState<Bookmark[]>([]);
+  const [lastRead, setLastReadState] = useState<Record<string, number>>({});
+  const [memorization, setMemorizationState] = useState<Record<string, MemorizationPlan>>({});
+  const [chapters, setChapters] = useState<Chapter[]>([]);
+
+  useEffect(() => {
+    void getChapters()
+      .then(setChapters)
+      .catch(() => {});
+    setFolders(loadBookmarksFromStorage());
+    setPinnedVerses(loadPinnedFromStorage());
+    setLastReadState(loadLastReadFromStorage());
+    setMemorizationState(loadMemorizationFromStorage());
+  }, []);
+
+  useEffect(() => saveBookmarksToStorage(folders), [folders]);
+  useEffect(() => savePinnedToStorage(pinnedVerses), [pinnedVerses]);
+  useEffect(() => saveLastReadToStorage(lastRead), [lastRead]);
+  useEffect(() => saveMemorizationToStorage(memorization), [memorization]);
+
+  return {
+    folders,
+    setFolders,
+    pinnedVerses,
+    setPinnedVerses,
+    lastRead,
+    setLastReadState,
+    memorization,
+    setMemorizationState,
+    chapters,
+  } as const;
+}

--- a/app/providers/bookmarks/hooks/useBookmarkMetadata.ts
+++ b/app/providers/bookmarks/hooks/useBookmarkMetadata.ts
@@ -1,0 +1,43 @@
+import { useCallback, type Dispatch, type SetStateAction } from 'react';
+
+import { getVerseById, getVerseByKey } from '@/lib/api/verses';
+
+import { updateBookmarkInFolders } from '../bookmark-utils';
+
+import type { Bookmark, Chapter, Folder } from '@/types';
+
+export function useBookmarkMetadata(
+  settings: { translationIds: number[]; translationId?: number },
+  setFolders: Dispatch<SetStateAction<Folder[]>>,
+  setPinnedVerses: Dispatch<SetStateAction<Bookmark[]>>
+): (verseId: string, chaptersList: Chapter[]) => Promise<void> {
+  return useCallback(
+    async (verseId: string, chaptersList: Chapter[]) => {
+      try {
+        const translationId = settings.translationIds[0] || settings.translationId || 20;
+        const isCompositeKey = /:/.test(verseId) || /[^0-9]/.test(verseId);
+        const verse = await (isCompositeKey
+          ? getVerseByKey(verseId, translationId)
+          : getVerseById(verseId, translationId));
+        const [surahIdStr] = verse.verse_key.split(':');
+        const surahInfo = chaptersList.find((chapter) => chapter.id === parseInt(surahIdStr));
+
+        const metadata = {
+          verseKey: verse.verse_key,
+          verseText: verse.text_uthmani,
+          surahName: surahInfo?.name_simple || `Surah ${surahIdStr}`,
+          translation: verse.translations?.[0]?.text,
+          verseApiId: verse.id,
+        };
+
+        setFolders((prev) => updateBookmarkInFolders(prev, verseId, metadata));
+        setPinnedVerses((prev) =>
+          prev.map((b) => (b.verseId === verseId ? { ...b, ...metadata } : b))
+        );
+      } catch {
+        // Silent fail for metadata fetch errors
+      }
+    },
+    [settings.translationIds, settings.translationId, setFolders, setPinnedVerses]
+  );
+}

--- a/app/providers/bookmarks/hooks/usePinnedBookmarks.ts
+++ b/app/providers/bookmarks/hooks/usePinnedBookmarks.ts
@@ -1,0 +1,28 @@
+import { useCallback } from 'react';
+
+import type useBookmarkOperations from './useBookmarkOperations';
+import type { Bookmark } from '@/types';
+
+export function usePinnedBookmarks(
+  pinnedVerses: Bookmark[],
+  bookmarkOps: ReturnType<typeof useBookmarkOperations>
+): { togglePinned: (verseId: string) => void; isPinned: (verseId: string) => boolean } {
+  const togglePinned = useCallback(
+    (verseId: string) => {
+      const isPinned = pinnedVerses.some((b) => b.verseId === verseId);
+      if (isPinned) {
+        bookmarkOps.removeBookmark(verseId, 'pinned');
+      } else {
+        bookmarkOps.addBookmark(verseId, 'pinned');
+      }
+    },
+    [pinnedVerses, bookmarkOps]
+  );
+
+  const isPinned = useCallback(
+    (verseId: string) => pinnedVerses.some((b) => b.verseId === verseId),
+    [pinnedVerses]
+  );
+
+  return { togglePinned, isPinned } as const;
+}

--- a/app/shared/components/adaptive-navigation/AdaptiveNavigation.tsx
+++ b/app/shared/components/adaptive-navigation/AdaptiveNavigation.tsx
@@ -17,39 +17,40 @@ interface AdaptiveNavigationProps {
   className?: string;
 }
 
-const navItemsFor = (breakpoint: string): NavItem[] => [
-  {
-    id: 'home',
-    icon: IconHome,
-    label: 'Home',
-    href: '/',
-    isActive: (path: string) => path === '/',
-  },
-  {
-    id: 'surah',
-    icon: IconBook,
-    label: breakpoint === 'mobile' ? 'Jump' : 'Jump to Surah',
-    isActive: (path: string) => path.startsWith('/surah'),
-    href: '/surah/1',
-  },
-  {
-    id: 'bookmarks',
-    icon: IconBookmark,
-    label: 'Bookmarks',
-    href: '/bookmarks',
-    isActive: (path: string) => path.startsWith('/bookmarks'),
-  },
-];
+const useNavItems = (breakpoint: string): NavItem[] =>
+  React.useMemo(
+    () => [
+      {
+        id: 'home',
+        icon: IconHome,
+        label: 'Home',
+        href: '/',
+        isActive: (path: string) => path === '/',
+      },
+      {
+        id: 'surah',
+        icon: IconBook,
+        label: breakpoint === 'mobile' ? 'Jump' : 'Jump to Surah',
+        isActive: (path: string) => path.startsWith('/surah'),
+        href: '/surah/1',
+      },
+      {
+        id: 'bookmarks',
+        icon: IconBookmark,
+        label: 'Bookmarks',
+        href: '/bookmarks',
+        isActive: (path: string) => path.startsWith('/bookmarks'),
+      },
+    ],
+    [breakpoint]
+  );
 
-export const AdaptiveNavigation = memo(function AdaptiveNavigation({
-  onSurahJump,
-  className,
-}: AdaptiveNavigationProps): React.JSX.Element | null {
-  const pathname = usePathname();
-  const { breakpoint, variant } = useResponsiveState();
-  const navItems = React.useMemo(() => navItemsFor(breakpoint), [breakpoint]);
-
-  const handleItemClick = React.useCallback(
+const useNavItemClick = (
+  onSurahJump: AdaptiveNavigationProps['onSurahJump'],
+  pathname: string,
+  breakpoint: string
+): ((item: NavItem, e: React.MouseEvent) => void) =>
+  React.useCallback(
     (item: NavItem, e: React.MouseEvent) => {
       if (item.id === 'surah') {
         const isOnSurahPage = pathname.startsWith('/surah/');
@@ -64,6 +65,15 @@ export const AdaptiveNavigation = memo(function AdaptiveNavigation({
     },
     [onSurahJump, pathname, breakpoint]
   );
+
+export const AdaptiveNavigation = memo(function AdaptiveNavigation({
+  onSurahJump,
+  className,
+}: AdaptiveNavigationProps): React.JSX.Element | null {
+  const pathname = usePathname();
+  const { breakpoint, variant } = useResponsiveState();
+  const navItems = useNavItems(breakpoint);
+  const handleItemClick = useNavItemClick(onSurahJump, pathname, breakpoint);
 
   if (pathname === '/') return null;
 

--- a/app/shared/navigation/QuranBottomSheet.tsx
+++ b/app/shared/navigation/QuranBottomSheet.tsx
@@ -3,9 +3,9 @@
 import { AnimatePresence, motion } from 'framer-motion';
 import { memo } from 'react';
 
-import { TabContent } from './components/TabContent';
 import { QuranBottomSheetHeader } from './components/QuranBottomSheetHeader';
 import { QuranTabBar } from './components/QuranTabBar';
+import { TabContent } from './components/TabContent';
 import { useBottomSheetHandlers } from './hooks/useBottomSheetHandlers';
 import { useQuranNavigation } from './hooks/useQuranNavigation';
 
@@ -41,31 +41,74 @@ export const QuranBottomSheet = memo(function QuranBottomSheet({
         <>
           <Backdrop onClose={onClose} />
           <Sheet>
-            <QuranBottomSheetHeader
+            <BottomSheetContent
               onClose={onClose}
               searchTerm={searchTerm}
               setSearchTerm={setSearchTerm}
-            />
-            <QuranTabBar
               tabs={tabs}
               activeTab={activeTab}
-              onTabChange={setActiveTab}
+              setActiveTab={setActiveTab}
+              filteredSurahs={filteredSurahs}
+              filteredJuzs={filteredJuzs}
+              filteredPages={filteredPages}
+              handleSurahClick={handleSurahClick}
+              handleJuzClick={handleJuzClick}
+              handlePageClick={handlePageClick}
             />
-            <div className="flex-1 overflow-y-auto">
-              <TabContent
-                activeTab={activeTab}
-                filteredSurahs={filteredSurahs}
-                filteredJuzs={filteredJuzs}
-                filteredPages={filteredPages}
-                onSurahClick={handleSurahClick}
-                onJuzClick={handleJuzClick}
-                onPageClick={handlePageClick}
-              />
-            </div>
           </Sheet>
         </>
       )}
     </AnimatePresence>
+  );
+});
+
+const BottomSheetContent = memo(function BottomSheetContent({
+  onClose,
+  searchTerm,
+  setSearchTerm,
+  tabs,
+  activeTab,
+  setActiveTab,
+  filteredSurahs,
+  filteredJuzs,
+  filteredPages,
+  handleSurahClick,
+  handleJuzClick,
+  handlePageClick,
+}: {
+  onClose: () => void;
+  searchTerm: string;
+  setSearchTerm: (term: string) => void;
+  tabs: { id: string; label: string }[];
+  activeTab: string;
+  setActiveTab: (tab: string) => void;
+  filteredSurahs: unknown[];
+  filteredJuzs: unknown[];
+  filteredPages: unknown[];
+  handleSurahClick: (id: number) => void;
+  handleJuzClick: (id: number) => void;
+  handlePageClick: (id: number) => void;
+}): React.ReactElement {
+  return (
+    <>
+      <QuranBottomSheetHeader
+        onClose={onClose}
+        searchTerm={searchTerm}
+        setSearchTerm={setSearchTerm}
+      />
+      <QuranTabBar tabs={tabs} activeTab={activeTab} onTabChange={setActiveTab} />
+      <div className="flex-1 overflow-y-auto">
+        <TabContent
+          activeTab={activeTab}
+          filteredSurahs={filteredSurahs}
+          filteredJuzs={filteredJuzs}
+          filteredPages={filteredPages}
+          onSurahClick={handleSurahClick}
+          onJuzClick={handleJuzClick}
+          onPageClick={handlePageClick}
+        />
+      </div>
+    </>
   );
 });
 
@@ -76,7 +119,7 @@ const sheetVariants = {
   exit: { y: '100%', opacity: 0 },
 };
 
-const Backdrop = ({ onClose }: { onClose: () => void }) => (
+const Backdrop = ({ onClose }: { onClose: () => void }): React.ReactElement => (
   <motion.div
     variants={backdropVariants}
     initial="hidden"
@@ -87,7 +130,7 @@ const Backdrop = ({ onClose }: { onClose: () => void }) => (
   />
 );
 
-const Sheet = ({ children }: { children: React.ReactNode }) => (
+const Sheet = ({ children }: { children: React.ReactNode }): React.ReactElement => (
   <motion.div
     variants={sheetVariants}
     initial="hidden"

--- a/app/shared/player/QuranAudioPlayer.tsx
+++ b/app/shared/player/QuranAudioPlayer.tsx
@@ -6,6 +6,8 @@ import { useQuranAudioController } from './hooks/useQuranAudioController';
 import { DesktopPlayerLayout } from './layouts/DesktopPlayerLayout';
 import { MobilePlayerLayout } from './layouts/MobilePlayerLayout';
 
+import type { DesktopPlayerLayoutProps } from './layouts/DesktopPlayerLayout';
+import type { MobilePlayerLayoutProps } from './layouts/MobilePlayerLayout';
 import type { Track } from './types';
 
 interface QuranAudioPlayerProps {
@@ -38,26 +40,8 @@ export function QuranAudioPlayer({
 
   return (
     <div className="relative w-full">
-      <div
-        className="mx-auto w-full rounded-2xl px-3 py-3 sm:px-4 sm:py-4 bg-surface shadow-lg border border-border"
-        role="region"
-        aria-label="Player"
-      >
-        {/* Mobile Layout */}
-        <div className="flex flex-col gap-3 sm:hidden">
-          <MobilePlayerLayout {...playerLayoutProps} />
-        </div>
-
-        {/* Desktop Layout */}
-        <div className="hidden sm:flex items-center gap-4">
-          <DesktopPlayerLayout {...playerLayoutProps} />
-        </div>
-      </div>
-      <audio ref={audioRef} src={track?.src || ''} preload="metadata" onEnded={handleEnded}>
-        <track kind="captions" />
-      </audio>
-
-      {/* Mobile Options Modal */}
+      <PlayerLayouts {...playerLayoutProps} />
+      <PlayerAudio ref={audioRef} src={track?.src || ''} onEnded={handleEnded} />
       <PlaybackOptionsModal
         open={mobileOptionsOpen}
         onClose={() => setMobileOptionsOpen(false)}
@@ -67,3 +51,35 @@ export function QuranAudioPlayer({
     </div>
   );
 }
+
+type PlayerLayoutProps = DesktopPlayerLayoutProps & MobilePlayerLayoutProps;
+
+const PlayerLayouts = React.memo(function PlayerLayouts(props: PlayerLayoutProps) {
+  return (
+    <div
+      className="mx-auto w-full rounded-2xl px-3 py-3 sm:px-4 sm:py-4 bg-surface shadow-lg border border-border"
+      role="region"
+      aria-label="Player"
+    >
+      <div className="flex flex-col gap-3 sm:hidden">
+        <MobilePlayerLayout {...props} />
+      </div>
+      <div className="hidden sm:flex items-center gap-4">
+        <DesktopPlayerLayout {...props} />
+      </div>
+    </div>
+  );
+});
+
+const PlayerAudio = React.memo(
+  React.forwardRef<HTMLAudioElement, { src: string; onEnded: () => void }>(function PlayerAudio(
+    { src, onEnded },
+    ref
+  ) {
+    return (
+      <audio ref={ref} src={src} preload="metadata" onEnded={onEnded}>
+        <track kind="captions" />
+      </audio>
+    );
+  })
+);


### PR DESCRIPTION
## Summary
- split Quran bottom sheet rendering into a memoized content component
- add dedicated layouts and audio elements for the Quran audio player
- refactor bookmark provider into smaller hooks and helpers
- simplify adaptive navigation with hooks for items and click handling

## Testing
- `npx eslint app/shared/navigation/QuranBottomSheet.tsx app/shared/player/QuranAudioPlayer.tsx app/providers/bookmarks/BookmarkProvider.tsx app/providers/bookmarks/hooks/useBookmarkData.ts app/providers/bookmarks/hooks/useBookmarkMetadata.ts app/providers/bookmarks/hooks/usePinnedBookmarks.ts app/shared/components/adaptive-navigation/AdaptiveNavigation.tsx`
- `npm run lint` *(fails: Unexpected console statement warnings)*

------
https://chatgpt.com/codex/tasks/task_b_68bd69f93a74832fb7a5c31ea8dee58f