### PR TITLE
refactor: extract panel and settings helpers

### DIFF
--- a/app/providers/TranslationProvider.tsx
+++ b/app/providers/TranslationProvider.tsx
@@ -7,6 +7,10 @@ import { i18n } from '../i18n';
  * Wraps the `I18nextProvider` to supply translation services via `react-i18next`.
  * Use this provider to enable hooks like `useTranslation` for any nested components.
  */
-export function TranslationProvider({ children }: { children: React.ReactNode }): React.JSX.Element {
+export function TranslationProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}): React.JSX.Element {
   return <I18nextProvider i18n={i18n}>{children}</I18nextProvider>;
 }

--- a/app/providers/hooks/panelController.ts
+++ b/app/providers/hooks/panelController.ts
@@ -1,0 +1,9 @@
+export const createPanelController = (
+  panelId: string,
+  openPanels: Set<string>,
+  open: (id: string) => void,
+  close: (id: string) => void
+) => ({
+  isOpen: openPanels.has(panelId),
+  setOpen: (state: boolean) => (state ? open(panelId) : close(panelId)),
+});

--- a/app/providers/hooks/useOpenPanels.ts
+++ b/app/providers/hooks/useOpenPanels.ts
@@ -1,0 +1,46 @@
+import { useCallback, useState } from 'react';
+
+interface OpenPanelsState {
+  openPanels: Set<string>;
+  openPanel: (panelId: string) => void;
+  closePanel: (panelId: string) => void;
+  togglePanel: (panelId: string) => void;
+  closeAllPanels: () => void;
+  isPanelOpen: (panelId: string) => boolean;
+}
+
+export const useOpenPanels = (): OpenPanelsState => {
+  const [openPanels, setOpenPanels] = useState<Set<string>>(new Set());
+
+  const openPanel = useCallback((panelId: string) => {
+    setOpenPanels((prev) => new Set([...prev, panelId]));
+  }, []);
+
+  const closePanel = useCallback((panelId: string) => {
+    setOpenPanels((prev) => {
+      const next = new Set(prev);
+      next.delete(panelId);
+      return next;
+    });
+  }, []);
+
+  const togglePanel = useCallback((panelId: string) => {
+    setOpenPanels((prev) => {
+      const next = new Set(prev);
+      if (next.has(panelId)) {
+        next.delete(panelId);
+      } else {
+        next.add(panelId);
+      }
+      return next;
+    });
+  }, []);
+
+  const closeAllPanels = useCallback(() => {
+    setOpenPanels(new Set());
+  }, []);
+
+  const isPanelOpen = useCallback((panelId: string) => openPanels.has(panelId), [openPanels]);
+
+  return { openPanels, openPanel, closePanel, togglePanel, closeAllPanels, isPanelOpen };
+};

--- a/app/providers/hooks/usePanelState.ts
+++ b/app/providers/hooks/usePanelState.ts
@@ -1,62 +1,35 @@
 'use client';
 
-import { useCallback, useMemo, useState } from 'react';
+import { useMemo } from 'react';
 
-export const usePanelState = () => {
-  const [openPanels, setOpenPanels] = useState<Set<string>>(new Set());
+import { createPanelController } from './panelController';
+import { useOpenPanels } from './useOpenPanels';
 
-  const openPanel = useCallback((panelId: string) => {
-    setOpenPanels((prev) => new Set([...prev, panelId]));
-  }, []);
+export interface PanelState {
+  openPanels: Set<string>;
+  openPanel: (panelId: string) => void;
+  closePanel: (panelId: string) => void;
+  togglePanel: (panelId: string) => void;
+  isPanelOpen: (panelId: string) => boolean;
+  closeAllPanels: () => void;
+  isSurahListOpen: boolean;
+  setSurahListOpen: (open: boolean) => void;
+  isSettingsOpen: boolean;
+  setSettingsOpen: (open: boolean) => void;
+}
 
-  const closePanel = useCallback((panelId: string) => {
-    setOpenPanels((prev) => {
-      const next = new Set(prev);
-      next.delete(panelId);
-      return next;
-    });
-  }, []);
+export const usePanelState = (): PanelState => {
+  const { openPanels, openPanel, closePanel, togglePanel, closeAllPanels, isPanelOpen } =
+    useOpenPanels();
 
-  const togglePanel = useCallback((panelId: string) => {
-    setOpenPanels((prev) => {
-      const next = new Set(prev);
-      if (next.has(panelId)) {
-        next.delete(panelId);
-      } else {
-        next.add(panelId);
-      }
-      return next;
-    });
-  }, []);
-
-  const isPanelOpen = useCallback((panelId: string) => openPanels.has(panelId), [openPanels]);
-
-  const closeAllPanels = useCallback(() => {
-    setOpenPanels(new Set());
-  }, []);
-
-  const isSurahListOpen = openPanels.has('surah-list');
-  const setSurahListOpen = useCallback(
-    (open: boolean) => {
-      if (open) {
-        openPanel('surah-list');
-      } else {
-        closePanel('surah-list');
-      }
-    },
-    [openPanel, closePanel]
+  const { isOpen: isSurahListOpen, setOpen: setSurahListOpen } = useMemo(
+    () => createPanelController('surah-list', openPanels, openPanel, closePanel),
+    [openPanels, openPanel, closePanel]
   );
 
-  const isSettingsOpen = openPanels.has('settings');
-  const setSettingsOpen = useCallback(
-    (open: boolean) => {
-      if (open) {
-        openPanel('settings');
-      } else {
-        closePanel('settings');
-      }
-    },
-    [openPanel, closePanel]
+  const { isOpen: isSettingsOpen, setOpen: setSettingsOpen } = useMemo(
+    () => createPanelController('settings', openPanels, openPanel, closePanel),
+    [openPanels, openPanel, closePanel]
   );
 
   return useMemo(

--- a/app/providers/settingsNormalization.ts
+++ b/app/providers/settingsNormalization.ts
@@ -1,0 +1,56 @@
+import { Settings } from '@/types';
+
+type RawSettings = Partial<Settings> & { tafsirId?: number };
+
+export const parseJson = <T>(value: string | null): T | null => {
+  if (!value) return null;
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    return null;
+  }
+};
+
+const applyLegacyFields = (settings: RawSettings): void => {
+  if (settings.tafsirId && !settings.tafsirIds) {
+    settings.tafsirIds = [settings.tafsirId];
+    delete settings.tafsirId;
+  }
+};
+
+const applySavedTranslations = (
+  settings: RawSettings,
+  savedTranslations: string | null,
+  defaults: Settings
+): void => {
+  if (!settings.translationIds && savedTranslations) {
+    const ids = parseJson<number[]>(savedTranslations);
+    if (Array.isArray(ids) && ids.length > 0) {
+      settings.translationIds = ids;
+      settings.translationId = ids[0];
+    }
+  }
+
+  if (!settings.translationIds) {
+    settings.translationIds = settings.translationId
+      ? [settings.translationId]
+      : [defaults.translationId];
+  }
+};
+
+const ensureTafsirIds = (settings: RawSettings, defaults: Settings): void => {
+  if (!settings.tafsirIds) {
+    settings.tafsirIds = defaults.tafsirIds;
+  }
+};
+
+export const normalizeSettings = (
+  raw: RawSettings,
+  savedTranslations: string | null,
+  defaults: Settings
+): Settings => {
+  applyLegacyFields(raw);
+  applySavedTranslations(raw, savedTranslations, defaults);
+  ensureTafsirIds(raw, defaults);
+  return { ...defaults, ...raw } as Settings;
+};

--- a/app/providers/settingsStorage.ts
+++ b/app/providers/settingsStorage.ts
@@ -1,6 +1,8 @@
 import { getItem, setItem } from '@/lib/utils/safeLocalStorage';
 import { Settings } from '@/types';
 
+import { parseJson, normalizeSettings } from './settingsNormalization';
+
 export const ARABIC_FONTS = [
   { name: 'KFGQPC Uthman Taha', value: '"KFGQPC-Uthman-Taha", serif', category: 'Uthmani' },
   { name: 'Amiri', value: '"Amiri", serif', category: 'Uthmani' },
@@ -31,48 +33,14 @@ const SELECTED_TRANSLATIONS_KEY = 'selected-translations';
 export const loadSettings = (defaults: Settings = defaultSettings): Settings => {
   if (typeof window === 'undefined') return defaults;
 
-  const savedSettings = getItem(SETTINGS_KEY);
-  const savedTranslations = getItem(SELECTED_TRANSLATIONS_KEY);
+  const savedSettings = parseJson(getItem(SETTINGS_KEY));
   if (!savedSettings) return defaults;
 
-  try {
-    const parsed = JSON.parse(savedSettings);
-
-    if (parsed.tafsirId && !parsed.tafsirIds) {
-      parsed.tafsirIds = [parsed.tafsirId];
-      delete parsed.tafsirId;
-    }
-
-    if (!parsed.translationIds && savedTranslations) {
-      try {
-        const translationIds = JSON.parse(savedTranslations);
-        if (Array.isArray(translationIds) && translationIds.length > 0) {
-          parsed.translationIds = translationIds;
-          parsed.translationId = translationIds[0];
-        }
-      } catch {
-        // Silent fail for translation parsing errors
-      }
-    }
-
-    if (!parsed.translationIds) {
-      parsed.translationIds = parsed.translationId
-        ? [parsed.translationId]
-        : [defaults.translationId];
-    }
-
-    if (!parsed.tafsirIds) {
-      parsed.tafsirIds = defaults.tafsirIds;
-    }
-
-    return { ...defaults, ...parsed } as Settings;
-  } catch {
-    // Silent fail for settings parsing errors
-    return defaults;
-  }
+  const savedTranslations = getItem(SELECTED_TRANSLATIONS_KEY);
+  return normalizeSettings(savedSettings, savedTranslations, defaults);
 };
 
-export const saveSettings = (settings: Settings) => {
+export const saveSettings = (settings: Settings): void => {
   if (typeof window === 'undefined') return;
   setItem(SETTINGS_KEY, JSON.stringify(settings));
 };


### PR DESCRIPTION
## Summary
- break out reusable panel controllers and state hook to simplify provider logic
- extract settings normalization helpers to reduce storage complexity
- format translation provider for lint compliance

## Testing
- `npx eslint src app/providers`
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*

------
https://chatgpt.com/codex/tasks/task_b_68bd6d0a83a4832f930941576ba87f4d