### PR TITLE
refactor: add verse utils and key handler

### DIFF
--- a/app/(features)/bookmarks/components/FolderVerseCard.tsx
+++ b/app/(features)/bookmarks/components/FolderVerseCard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import React from 'react';
-
+import { parseVerseKey } from '@/lib/utils/verse';
+import { handleKeyboardActivation } from '@/lib/utils/keyboard';
 import { cn } from '@/lib/utils/cn';
 
 import type { Bookmark } from '@/types/bookmark';
@@ -17,54 +17,33 @@ export const FolderVerseCard = ({
   onClick,
   className,
 }: FolderVerseCardProps): React.JSX.Element => {
-  // Parse verse key to get surah and ayah numbers
-  const parseVerseKey = (verseKey?: string) => {
-    if (!verseKey) return { surahNumber: 0, ayahNumber: 0 };
-    const [surah, ayah] = verseKey.split(':').map(Number);
-    return { surahNumber: surah || 0, ayahNumber: ayah || 0 };
-  };
-
   const { surahNumber, ayahNumber } = parseVerseKey(bookmark.verseKey);
 
   return (
     <div
       onClick={onClick}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault();
-          onClick?.();
-        }
-      }}
+      onKeyDown={(e) => handleKeyboardActivation(e, onClick)}
       role="button"
       tabIndex={0}
       className={cn(
-        'p-2.5 rounded-lg border transition-all duration-200 cursor-pointer group',
+        'group min-h-0 cursor-pointer rounded-lg border p-2.5 transition-all duration-200',
         'bg-surface/60 border-border/60 hover:border-accent/30 hover:bg-surface-hover hover:shadow-sm',
-        'min-h-0', // Allow shrinking
         className
       )}
     >
       <div className="flex items-start space-x-2.5">
-        {/* Verse indicator */}
-        <div className="flex-shrink-0 w-7 h-7 rounded-md bg-accent/10 text-accent flex items-center justify-center text-xs font-semibold group-hover:bg-accent/15">
+        <div className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-md bg-accent/10 text-xs font-semibold text-accent group-hover:bg-accent/15">
           {ayahNumber}
         </div>
-
-        {/* Content */}
-        <div className="flex-1 min-w-0">
-          {/* Surah info */}
-          <div className="text-xs font-semibold text-foreground truncate">
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-xs font-semibold text-foreground">
             {bookmark.surahName || `Surah ${surahNumber}`}
           </div>
-
-          {/* Verse key */}
-          <div className="text-xs text-muted/80 leading-tight">
+          <div className="text-xs leading-tight text-muted/80">
             {bookmark.verseKey || `${surahNumber}:${ayahNumber}`}
           </div>
-
-          {/* Optional verse preview - only show translation or first few words */}
           {(bookmark.translation || bookmark.verseText) && (
-            <div className="text-xs text-muted-foreground mt-1 line-clamp-1 leading-tight">
+            <div className="mt-1 line-clamp-1 text-xs leading-tight text-muted-foreground">
               {bookmark.translation
                 ? bookmark.translation.length > 50
                   ? `${bookmark.translation.substring(0, 50)}...`

--- a/app/shared/ui/cards/BookmarkVerseCard.tsx
+++ b/app/shared/ui/cards/BookmarkVerseCard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { cn } from '@/lib/utils/cn';
+import { parseVerseKey } from '@/lib/utils/verse';
 
 import { BaseCard, BaseCardProps } from '../BaseCard';
 
@@ -22,13 +23,6 @@ export const BookmarkVerseCard = ({
   className,
   ...props
 }: BookmarkVerseCardProps): React.JSX.Element => {
-  // Parse verse key to get surah and ayah numbers
-  const parseVerseKey = (verseKey?: string) => {
-    if (!verseKey) return { surahNumber: 0, ayahNumber: 0 };
-    const [surah, ayah] = verseKey.split(':').map(Number);
-    return { surahNumber: surah || 0, ayahNumber: ayah || 0 };
-  };
-
   const { surahNumber, ayahNumber } = parseVerseKey(bookmark.verseKey);
 
   return (

--- a/lib/utils/__tests__/keyboard.test.ts
+++ b/lib/utils/__tests__/keyboard.test.ts
@@ -1,0 +1,28 @@
+import type React from 'react';
+import { handleKeyboardActivation } from '../keyboard';
+
+describe('handleKeyboardActivation', () => {
+  it('calls callback on Enter', () => {
+    const cb = jest.fn();
+    const event = { key: 'Enter', preventDefault: jest.fn() } as unknown as React.KeyboardEvent;
+    handleKeyboardActivation(event, cb);
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(cb).toHaveBeenCalled();
+  });
+
+  it('calls callback on space', () => {
+    const cb = jest.fn();
+    const event = { key: ' ', preventDefault: jest.fn() } as unknown as React.KeyboardEvent;
+    handleKeyboardActivation(event, cb);
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(cb).toHaveBeenCalled();
+  });
+
+  it('ignores other keys', () => {
+    const cb = jest.fn();
+    const event = { key: 'Escape', preventDefault: jest.fn() } as unknown as React.KeyboardEvent;
+    handleKeyboardActivation(event, cb);
+    expect(event.preventDefault).not.toHaveBeenCalled();
+    expect(cb).not.toHaveBeenCalled();
+  });
+});

--- a/lib/utils/__tests__/verse.test.ts
+++ b/lib/utils/__tests__/verse.test.ts
@@ -1,0 +1,15 @@
+import { parseVerseKey } from '../verse';
+
+describe('parseVerseKey', () => {
+  it('parses valid verse key', () => {
+    expect(parseVerseKey('2:255')).toEqual({ surahNumber: 2, ayahNumber: 255 });
+  });
+
+  it('returns zeros for missing key', () => {
+    expect(parseVerseKey(undefined)).toEqual({ surahNumber: 0, ayahNumber: 0 });
+  });
+
+  it('handles invalid format', () => {
+    expect(parseVerseKey('abc')).toEqual({ surahNumber: 0, ayahNumber: 0 });
+  });
+});

--- a/lib/utils/keyboard.ts
+++ b/lib/utils/keyboard.ts
@@ -1,0 +1,7 @@
+import type React from 'react';
+export const handleKeyboardActivation = (e: React.KeyboardEvent, callback?: () => void): void => {
+  if (e.key === 'Enter' || e.key === ' ') {
+    e.preventDefault();
+    callback?.();
+  }
+};

--- a/lib/utils/verse.ts
+++ b/lib/utils/verse.ts
@@ -1,0 +1,10 @@
+export interface ParsedVerseKey {
+  surahNumber: number;
+  ayahNumber: number;
+}
+
+export const parseVerseKey = (verseKey?: string): ParsedVerseKey => {
+  if (!verseKey) return { surahNumber: 0, ayahNumber: 0 };
+  const [surah, ayah] = verseKey.split(':').map(Number);
+  return { surahNumber: surah || 0, ayahNumber: ayah || 0 };
+};


### PR DESCRIPTION
## Summary
- move verse key parsing and keyboard activation to shared utilities
- consume new utilities in FolderVerseCard and BookmarkVerseCard

## Testing
- `npm run lint` (fails: Cannot find package '@eslint/eslintrc`)
- `npm run test` (fails: jest: not found)
- `npm run type-check` (fails: Cannot find type definition file for '@testing-library/jest-dom`)


------
https://chatgpt.com/codex/tasks/task_b_68bd801a57e0832f9aaefb269ea5bbf5