### PR TITLE
refactor: memoize bookmark callbacks

### DIFF
--- a/app/(features)/bookmarks/components/DeleteFolderModal.tsx
+++ b/app/(features)/bookmarks/components/DeleteFolderModal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { motion, AnimatePresence } from 'framer-motion';
-import React from 'react';
+import React, { useCallback } from 'react';
 import { Folder } from '@/types';
 
 import { BACKDROP_VARIANTS, ModalBody, useDeleteFolder } from './delete-folder-modal';
@@ -17,7 +17,10 @@ export const DeleteFolderModal = ({
   onClose,
   folder,
 }: DeleteFolderModalProps): React.JSX.Element => {
-  const { handleDelete, isDeleting } = useDeleteFolder(folder, onClose);
+  const { handleDelete: deleteFolder, isDeleting } = useDeleteFolder(folder, onClose);
+  const handleDelete = useCallback(() => {
+    deleteFolder();
+  }, [deleteFolder]);
 
   return (
     <AnimatePresence>

--- a/app/(features)/bookmarks/components/FolderContextMenu.tsx
+++ b/app/(features)/bookmarks/components/FolderContextMenu.tsx
@@ -68,24 +68,29 @@ export const FolderContextMenu = ({
     };
   }, [isOpen, handleClickOutside]);
 
-  const handleToggleMenu = useCallback((e: React.MouseEvent<HTMLButtonElement>): void => {
-    e.stopPropagation();
-    setIsOpen((prev) => !prev);
-  }, []);
+  const handleToggleMenu = useCallback(
+    (e: React.MouseEvent<HTMLButtonElement>): void => {
+      e.stopPropagation();
+      setIsOpen((prev) => !prev);
+    },
+    []
+  );
 
-  const handleEdit = useCallback((): void => {
-    onEdit();
-    handleCloseMenu();
-  }, [onEdit, handleCloseMenu]);
-
-  const handleDelete = useCallback((): void => {
-    onDelete();
-    handleCloseMenu();
-  }, [onDelete, handleCloseMenu]);
+  const handleAction = useCallback(
+    (action: 'edit' | 'delete'): void => {
+      if (action === 'edit') {
+        onEdit();
+      } else {
+        onDelete();
+      }
+      handleCloseMenu();
+    },
+    [onEdit, onDelete, handleCloseMenu]
+  );
 
   const menuItems = [
-    { label: 'Edit', onClick: handleEdit },
-    { label: 'Delete', onClick: handleDelete, destructive: true },
+    { label: 'Edit', onClick: () => handleAction('edit') },
+    { label: 'Delete', onClick: () => handleAction('delete'), destructive: true },
   ];
 
   return (

--- a/app/(features)/bookmarks/components/FolderGrid.tsx
+++ b/app/(features)/bookmarks/components/FolderGrid.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { motion, AnimatePresence } from 'framer-motion';
-import React, { useState } from 'react';
+import React, { useCallback, useState } from 'react';
 
 import { DeleteFolderModal } from './DeleteFolderModal';
 import { EmptyBookmarks, EmptySearch } from './EmptyStates';
@@ -81,15 +81,18 @@ const useFolderModals = () => {
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const [modalMode, setModalMode] = useState<'edit' | 'rename' | 'customize'>('edit');
 
-  const handleAction = (folder: Folder, action: FolderAction): void => {
-    setSelectedFolder(folder);
-    if (action === 'delete') {
-      setDeleteModalOpen(true);
-      return;
-    }
-    setModalMode(action);
-    setSettingsModalOpen(true);
-  };
+  const handleFolderAction = useCallback(
+    (folder: Folder, action: FolderAction): void => {
+      setSelectedFolder(folder);
+      if (action === 'delete') {
+        setDeleteModalOpen(true);
+        return;
+      }
+      setModalMode(action);
+      setSettingsModalOpen(true);
+    },
+    []
+  );
 
   const closeModals = (): void => {
     setSettingsModalOpen(false);
@@ -113,7 +116,7 @@ const useFolderModals = () => {
     </>
   );
 
-  return { handleAction, modals };
+  return { handleFolderAction, modals };
 };
 
 export const FolderGrid = ({
@@ -124,7 +127,7 @@ export const FolderGrid = ({
   searchTerm,
   onClearSearch,
 }: FolderGridProps): React.JSX.Element => {
-  const { handleAction, modals } = useFolderModals();
+  const { handleFolderAction, modals } = useFolderModals();
 
   if (folders.length === 0) {
     if (allFolders.length === 0) {
@@ -145,7 +148,7 @@ export const FolderGrid = ({
       <FolderCards
         folders={folders}
         onFolderSelect={onFolderSelect}
-        onAction={handleAction}
+        onAction={handleFolderAction}
       />
       {modals}
     </>

--- a/app/(features)/bookmarks/components/create-folder-modal/QuickSuggestions.tsx
+++ b/app/(features)/bookmarks/components/create-folder-modal/QuickSuggestions.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { useCallback } from 'react';
 
 const QUICK_SUGGESTIONS = ['Daily Reading', 'Memorization', 'Reflection', 'Favorite Verses'];
 
@@ -10,20 +10,29 @@ interface QuickSuggestionsProps {
 
 export const QuickSuggestions = ({
   onSuggestionClick,
-}: QuickSuggestionsProps): React.JSX.Element => (
-  <div className="mt-8 pt-6 border-t border-border">
-    <h3 className="text-sm font-semibold text-foreground mb-3">Quick Suggestions</h3>
-    <div className="flex flex-wrap gap-2">
-      {QUICK_SUGGESTIONS.map((suggestion) => (
-        <button
-          key={suggestion}
-          type="button"
-          onClick={() => onSuggestionClick(suggestion)}
-          className="px-3 py-1.5 text-xs bg-surface border border-border rounded-lg hover:bg-accent/10 hover:border-accent/20 transition-colors duration-200 text-muted hover:text-foreground"
-        >
-          {suggestion}
-        </button>
-      ))}
+}: QuickSuggestionsProps): React.JSX.Element => {
+  const handleSuggestionClick = useCallback(
+    (suggestion: string): void => {
+      onSuggestionClick(suggestion);
+    },
+    [onSuggestionClick]
+  );
+
+  return (
+    <div className="mt-8 pt-6 border-t border-border">
+      <h3 className="text-sm font-semibold text-foreground mb-3">Quick Suggestions</h3>
+      <div className="flex flex-wrap gap-2">
+        {QUICK_SUGGESTIONS.map((suggestion) => (
+          <button
+            key={suggestion}
+            type="button"
+            onClick={() => handleSuggestionClick(suggestion)}
+            className="px-3 py-1.5 text-xs bg-surface border border-border rounded-lg hover:bg-accent/10 hover:border-accent/20 transition-colors duration-200 text-muted hover:text-foreground"
+          >
+            {suggestion}
+          </button>
+        ))}
+      </div>
     </div>
-  </div>
-);
+  );
+};

--- a/app/(features)/bookmarks/hooks/useBookmarkListState.ts
+++ b/app/(features)/bookmarks/hooks/useBookmarkListState.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import type { Bookmark, Folder } from '@/types';
 
@@ -15,14 +15,15 @@ export const useBookmarkListState = (
   const [bookmarks, setBookmarks] = useState<Bookmark[]>(externalBookmarks || folder.bookmarks);
   const [listHeight, setListHeight] = useState(0);
 
+  const updateHeight = useCallback((): void => {
+    setListHeight(window.innerHeight - 200);
+  }, []);
+
   useEffect(() => {
-    const updateHeight = (): void => {
-      setListHeight(window.innerHeight - 200);
-    };
     updateHeight();
     window.addEventListener('resize', updateHeight);
     return () => window.removeEventListener('resize', updateHeight);
-  }, []);
+  }, [updateHeight]);
 
   useEffect(() => {
     if (externalBookmarks) {
@@ -32,9 +33,9 @@ export const useBookmarkListState = (
     }
   }, [externalBookmarks, folder.bookmarks]);
 
-  const handleRemoveBookmark = (verseId: string): void => {
+  const handleRemoveBookmark = useCallback((verseId: string): void => {
     setBookmarks((prev) => prev.filter((bookmark) => bookmark.verseId !== verseId));
-  };
+  }, []);
 
   return { bookmarks, listHeight, handleRemoveBookmark };
 };


### PR DESCRIPTION
## Summary
- memoize folder action handler in bookmarks grid
- stabilize bookmark list height and removal callbacks
- memoize quick suggestion, context menu, and delete modal actions

## Testing
- `npm test` *(fails: SyntaxError: Cannot use import statement outside a module)*
- `npm run lint`
- `npm run type-check` *(fails: Type 'string | undefined' is not assignable to type 'string')*

------
https://chatgpt.com/codex/tasks/task_b_68bd8c3c04bc832fa28aa549b38e25e5