### PR TITLE
fix: show error on folder deletion failure

### DIFF
--- a/app/(features)/bookmarks/components/DeleteFolderModal.tsx
+++ b/app/(features)/bookmarks/components/DeleteFolderModal.tsx
@@ -17,7 +17,7 @@ export const DeleteFolderModal = ({
   onClose,
   folder,
 }: DeleteFolderModalProps): React.JSX.Element => {
-  const { handleDelete, isDeleting } = useDeleteFolder(folder, onClose);
+  const { handleDelete, isDeleting, error } = useDeleteFolder(folder, onClose);
 
   return (
     <AnimatePresence>
@@ -38,6 +38,7 @@ export const DeleteFolderModal = ({
             onClose={onClose}
             onDelete={handleDelete}
             isDeleting={isDeleting}
+            error={error}
           />
         </>
       )}

--- a/app/(features)/bookmarks/components/delete-folder-modal/ModalBody.tsx
+++ b/app/(features)/bookmarks/components/delete-folder-modal/ModalBody.tsx
@@ -14,6 +14,7 @@ interface ModalBodyProps {
   onClose: () => void;
   onDelete: () => void;
   isDeleting: boolean;
+  error?: string | null;
 }
 
 export const ModalBody = ({
@@ -21,6 +22,7 @@ export const ModalBody = ({
   onClose,
   onDelete,
   isDeleting,
+  error,
 }: ModalBodyProps): React.JSX.Element => (
   <motion.div
     variants={MODAL_VARIANTS}
@@ -38,6 +40,11 @@ export const ModalBody = ({
       <div className="space-y-4">
         <p className="text-foreground">Are you sure you want to permanently delete this folder?</p>
         <WarningMessage folder={folder} />
+        {error && (
+          <p role="alert" className="text-error text-sm">
+            {error}
+          </p>
+        )}
       </div>
 
       <ModalActions onClose={onClose} onDelete={onDelete} isDeleting={isDeleting} />

--- a/app/(features)/bookmarks/components/delete-folder-modal/useDeleteFolder.ts
+++ b/app/(features)/bookmarks/components/delete-folder-modal/useDeleteFolder.ts
@@ -7,22 +7,25 @@ import { Folder } from '@/types';
 export const useDeleteFolder = (folder: Folder | null, onClose: () => void) => {
   const { deleteFolder } = useBookmarks();
   const [isDeleting, setIsDeleting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const handleDelete = useCallback(async () => {
     if (!folder) return;
 
     setIsDeleting(true);
+    setError(null);
     try {
       deleteFolder(folder.id);
       onClose();
     } catch (error) {
       logger.error('Failed to delete folder:', undefined, error as Error);
+      setError('Failed to delete folder. Please try again.');
     } finally {
       setIsDeleting(false);
     }
   }, [deleteFolder, folder, onClose]);
 
-  return { handleDelete, isDeleting };
+  return { handleDelete, isDeleting, error };
 };
 
 export type UseDeleteFolderReturn = ReturnType<typeof useDeleteFolder>;


### PR DESCRIPTION
## Summary
- show inline error message if a folder can't be deleted
- surface deletion errors in DeleteFolderModal

## Testing
- `npm run check` *(fails: Cannot find package '@eslint/eslintrc' imported from eslint.config.mjs)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68bd8c3e7ac8832f9525eed9a934c203