### PR TITLE
refactor: split playback completion handlers

### DIFF
--- a/app/shared/player/hooks/finalizeHandler.ts
+++ b/app/shared/player/hooks/finalizeHandler.ts
@@ -1,0 +1,30 @@
+import { RefObject } from 'react';
+
+interface FinalizeArgs {
+  onNext?: () => boolean;
+  audioRef: RefObject<HTMLAudioElement | null>;
+  pause: () => void;
+  setIsPlaying: (v: boolean) => void;
+  setPlayingId: (v: number | null) => void;
+}
+
+export function createFinalizeHandler({
+  onNext,
+  audioRef,
+  pause,
+  setIsPlaying,
+  setPlayingId,
+}: FinalizeArgs): () => void {
+  return () => {
+    const hasNext = onNext?.() ?? false;
+    setTimeout(() => {
+      if (!hasNext || !audioRef.current?.src) {
+        pause();
+        setIsPlaying(false);
+        setPlayingId(null);
+      }
+    }, 0);
+  };
+}
+
+export type { FinalizeArgs };

--- a/app/shared/player/hooks/playbackCompletionHandlers.ts
+++ b/app/shared/player/hooks/playbackCompletionHandlers.ts
@@ -1,118 +1,6 @@
-/* eslint-disable max-lines, max-lines-per-function */
-import { RefObject } from 'react';
-
-interface SingleRepeatArgs {
-  verseRepeatsLeft: number;
-  playRepeatsLeft: number;
-  repeatEach: number;
-  seek: (s: number) => void;
-  play: () => void;
-  setVerseRepeatsLeft: (n: number) => void;
-  setPlayRepeatsLeft: (n: number) => void;
-}
-
-export function handleSingleRepeat({
-  verseRepeatsLeft,
-  playRepeatsLeft,
-  repeatEach,
-  seek,
-  play,
-  setVerseRepeatsLeft,
-  setPlayRepeatsLeft,
-}: SingleRepeatArgs): boolean {
-  if (verseRepeatsLeft > 1) {
-    setVerseRepeatsLeft(verseRepeatsLeft - 1);
-    seek(0);
-    play();
-    return true;
-  }
-  if (playRepeatsLeft > 1) {
-    setPlayRepeatsLeft(playRepeatsLeft - 1);
-    setVerseRepeatsLeft(repeatEach);
-    seek(0);
-    play();
-    return true;
-  }
-  return false;
-}
-
-interface RangeRepeatArgs {
-  start: number;
-  end: number;
-  currentAyah: number | null;
-  delay: number;
-  verseRepeatsLeft: number;
-  repeatEach: number;
-  onNext?: () => boolean;
-  onPrev?: () => boolean;
-  seek: (s: number) => void;
-  play: () => void;
-  setVerseRepeatsLeft: (n: number) => void;
-  setPlayRepeatsLeft: (n: number) => void;
-  playRepeatsLeft: number;
-}
-
-export function handleRangeRepeat({
-  start,
-  end,
-  currentAyah,
-  delay,
-  verseRepeatsLeft,
-  repeatEach,
-  onNext,
-  onPrev,
-  seek,
-  play,
-  setVerseRepeatsLeft,
-  setPlayRepeatsLeft,
-  playRepeatsLeft,
-}: RangeRepeatArgs): boolean {
-  if (verseRepeatsLeft > 1) {
-    setVerseRepeatsLeft(verseRepeatsLeft - 1);
-    seek(0);
-    play();
-    return true;
-  }
-  setVerseRepeatsLeft(repeatEach);
-  if (currentAyah && currentAyah < end) {
-    onNext?.();
-    return true;
-  }
-  if (playRepeatsLeft > 1) {
-    setPlayRepeatsLeft(playRepeatsLeft - 1);
-    const steps = end - start;
-    setTimeout(() => {
-      for (let i = 0; i < steps; i++) onPrev?.();
-    }, delay);
-    return true;
-  }
-  return false;
-}
-
-interface FinalizeArgs {
-  onNext?: () => boolean;
-  audioRef: RefObject<HTMLAudioElement | null>;
-  pause: () => void;
-  setIsPlaying: (v: boolean) => void;
-  setPlayingId: (v: number | null) => void;
-}
-
-export function finalizePlayback({
-  onNext,
-  audioRef,
-  pause,
-  setIsPlaying,
-  setPlayingId,
-}: FinalizeArgs): void {
-  const hasNext = onNext?.() ?? false;
-  setTimeout(() => {
-    if (!hasNext || !audioRef.current?.src) {
-      pause();
-      setIsPlaying(false);
-      setPlayingId(null);
-    }
-  }, 0);
-}
+import { createFinalizeHandler, FinalizeArgs } from './finalizeHandler';
+import { createRangeRepeatHandler, RangeRepeatArgs } from './rangeRepeatHandler';
+import { createSingleRepeatHandler } from './singleRepeatHandler';
 
 export interface CompletionHandlers {
   single: () => boolean;
@@ -121,75 +9,15 @@ export interface CompletionHandlers {
   default: () => void;
 }
 
-interface CreateHandlersArgs {
-  start: number;
-  end: number;
-  delay: number;
-  currentAyah: number | null;
-  verseRepeatsLeft: number;
-  playRepeatsLeft: number;
-  repeatEach: number;
-  onNext?: () => boolean;
-  onPrev?: () => boolean;
-  seek: (s: number) => void;
-  play: () => void;
-  pause: () => void;
-  audioRef: RefObject<HTMLAudioElement | null>;
-  setVerseRepeatsLeft: (n: number) => void;
-  setPlayRepeatsLeft: (n: number) => void;
-  setIsPlaying: (v: boolean) => void;
-  setPlayingId: (v: number | null) => void;
+interface CreateHandlersArgs extends RangeRepeatArgs, FinalizeArgs {
   handleSurahRepeat: () => void;
 }
 
-export function createCompletionHandlers({
-  start,
-  end,
-  delay,
-  currentAyah,
-  verseRepeatsLeft,
-  playRepeatsLeft,
-  repeatEach,
-  onNext,
-  onPrev,
-  seek,
-  play,
-  pause,
-  audioRef,
-  setVerseRepeatsLeft,
-  setPlayRepeatsLeft,
-  setIsPlaying,
-  setPlayingId,
-  handleSurahRepeat,
-}: CreateHandlersArgs): CompletionHandlers {
+export function createCompletionHandlers(args: CreateHandlersArgs): CompletionHandlers {
   return {
-    single: () =>
-      handleSingleRepeat({
-        verseRepeatsLeft,
-        playRepeatsLeft,
-        repeatEach,
-        seek,
-        play,
-        setVerseRepeatsLeft,
-        setPlayRepeatsLeft,
-      }),
-    range: () =>
-      handleRangeRepeat({
-        start,
-        end,
-        currentAyah,
-        delay,
-        verseRepeatsLeft,
-        repeatEach,
-        onNext,
-        onPrev,
-        seek,
-        play,
-        setVerseRepeatsLeft,
-        setPlayRepeatsLeft,
-        playRepeatsLeft,
-      }),
-    surah: handleSurahRepeat,
-    default: () => finalizePlayback({ onNext, audioRef, pause, setIsPlaying, setPlayingId }),
+    single: createSingleRepeatHandler(args),
+    range: createRangeRepeatHandler(args),
+    surah: args.handleSurahRepeat,
+    default: createFinalizeHandler(args),
   };
 }

--- a/app/shared/player/hooks/rangeRepeatHandler.ts
+++ b/app/shared/player/hooks/rangeRepeatHandler.ts
@@ -1,0 +1,56 @@
+interface RangeRepeatArgs {
+  start: number;
+  end: number;
+  currentAyah: number | null;
+  delay: number;
+  verseRepeatsLeft: number;
+  repeatEach: number;
+  onNext?: () => boolean;
+  onPrev?: () => boolean;
+  seek: (s: number) => void;
+  play: () => void;
+  setVerseRepeatsLeft: (n: number) => void;
+  setPlayRepeatsLeft: (n: number) => void;
+  playRepeatsLeft: number;
+}
+
+export function createRangeRepeatHandler({
+  start,
+  end,
+  currentAyah,
+  delay,
+  verseRepeatsLeft,
+  repeatEach,
+  onNext,
+  onPrev,
+  seek,
+  play,
+  setVerseRepeatsLeft,
+  setPlayRepeatsLeft,
+  playRepeatsLeft,
+}: RangeRepeatArgs): () => boolean {
+  return () => {
+    if (verseRepeatsLeft > 1) {
+      setVerseRepeatsLeft(verseRepeatsLeft - 1);
+      seek(0);
+      play();
+      return true;
+    }
+    setVerseRepeatsLeft(repeatEach);
+    if (currentAyah && currentAyah < end) {
+      onNext?.();
+      return true;
+    }
+    if (playRepeatsLeft > 1) {
+      setPlayRepeatsLeft(playRepeatsLeft - 1);
+      const steps = end - start;
+      setTimeout(() => {
+        for (let i = 0; i < steps; i++) onPrev?.();
+      }, delay);
+      return true;
+    }
+    return false;
+  };
+}
+
+export type { RangeRepeatArgs };

--- a/app/shared/player/hooks/singleRepeatHandler.ts
+++ b/app/shared/player/hooks/singleRepeatHandler.ts
@@ -1,0 +1,38 @@
+interface SingleRepeatArgs {
+  verseRepeatsLeft: number;
+  playRepeatsLeft: number;
+  repeatEach: number;
+  seek: (s: number) => void;
+  play: () => void;
+  setVerseRepeatsLeft: (n: number) => void;
+  setPlayRepeatsLeft: (n: number) => void;
+}
+
+export function createSingleRepeatHandler({
+  verseRepeatsLeft,
+  playRepeatsLeft,
+  repeatEach,
+  seek,
+  play,
+  setVerseRepeatsLeft,
+  setPlayRepeatsLeft,
+}: SingleRepeatArgs): () => boolean {
+  return () => {
+    if (verseRepeatsLeft > 1) {
+      setVerseRepeatsLeft(verseRepeatsLeft - 1);
+      seek(0);
+      play();
+      return true;
+    }
+    if (playRepeatsLeft > 1) {
+      setPlayRepeatsLeft(playRepeatsLeft - 1);
+      setVerseRepeatsLeft(repeatEach);
+      seek(0);
+      play();
+      return true;
+    }
+    return false;
+  };
+}
+
+export type { SingleRepeatArgs };


### PR DESCRIPTION
## Summary
- split playback completion logic into single, range, and finalize handler modules
- assemble handlers in playbackCompletionHandlers without disabling lint rules

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68bea6ef501c832fb1f8a6ea66e4c3b9