### PR TITLE
test: wire msw server in jest setup

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -160,6 +160,11 @@ describe('SettingsContext', () => {
 
 ### API Mocking
 
+Tests use [MSW](https://mswjs.io/) to intercept network requests and prevent
+external calls. Real network access is disabled unless explicitly re-enabled.
+Set `JEST_ALLOW_NETWORK=1` before running tests to opt out and allow raw
+network requests.
+
 ```typescript
 // Mock SWR
 jest.mock('swr', () => ({
@@ -167,7 +172,7 @@ jest.mock('swr', () => ({
   default: jest.fn(() => ({ data: mockData, error: null, isLoading: false })),
 }));
 
-// Mock fetch
+// Example of manual fetch mocking if needed
 global.fetch = jest.fn(() =>
   Promise.resolve({
     ok: true,


### PR DESCRIPTION
## Summary
- replace QDC fetch stubs with MSW server
- start/stop MSW in global Jest hooks
- document `JEST_ALLOW_NETWORK` opt-out in testing guide

## Testing
- `npm test` *(fails: 18 failed, 133 passed)*
- `npx eslint jest.setup.js docs/TESTING.md` *(warnings)*

------
https://chatgpt.com/codex/tasks/task_b_68c669e1cbcc832fa82c48aa81365a9f