### PR TITLE
test: await async updates and enforce async lint

### DIFF
--- a/app/providers/__tests__/BookmarkContext/BookmarkContext.initial-state.test.tsx
+++ b/app/providers/__tests__/BookmarkContext/BookmarkContext.initial-state.test.tsx
@@ -12,9 +12,11 @@ describe('BookmarkContext initial state', () => {
     localStorage.clear();
   });
 
-  it('initializes with an empty array of folders', () => {
+  it('initializes with an empty array of folders', async () => {
     renderWithProviders(<BookmarkTestComponent />);
-    expect(screen.getByTestId('folders').textContent).toBe('[]');
+    await waitFor(() => {
+      expect(screen.getByTestId('folders').textContent).toBe('[]');
+    });
   });
 
   it('migrates old bookmarks from localStorage', async () => {

--- a/app/providers/__tests__/BookmarkContext/BookmarkContext.operations.test.tsx
+++ b/app/providers/__tests__/BookmarkContext/BookmarkContext.operations.test.tsx
@@ -7,8 +7,13 @@ import type { Bookmark, Folder } from '@/types';
 
 const BOOKMARKS_STORAGE_KEY = 'quranAppBookmarks_v2';
 
-const renderComponent = (): ReturnType<typeof renderWithProviders> =>
-  renderWithProviders(<BookmarkTestComponent />);
+const renderComponent = async (): Promise<ReturnType<typeof renderWithProviders>> => {
+  const result = renderWithProviders(<BookmarkTestComponent />);
+  await waitFor(() => {
+    expect(screen.getByTestId('folders')).toBeInTheDocument();
+  });
+  return result;
+};
 
 const getFolders = (): Folder[] => JSON.parse(screen.getByTestId('folders').textContent || '[]');
 
@@ -26,7 +31,7 @@ beforeEach(() => {
 });
 
 it('creates a new folder', async () => {
-  renderComponent();
+  await renderComponent();
   await userEvent.click(screen.getByText('Create Folder'));
   await waitFor(() => {
     const folders = getFolders();
@@ -36,7 +41,7 @@ it('creates a new folder', async () => {
 });
 
 it('adds a bookmark to a folder', async () => {
-  renderComponent();
+  await renderComponent();
   await userEvent.click(screen.getByText('Create Folder'));
   await userEvent.click(screen.getByText('Add Bookmark'));
   await waitFor(() => {
@@ -48,7 +53,7 @@ it('adds a bookmark to a folder', async () => {
 });
 
 it('removes a bookmark from a folder', async () => {
-  renderComponent();
+  await renderComponent();
   await userEvent.click(screen.getByText('Create Folder'));
   await userEvent.click(screen.getByText('Add Bookmark'));
   await userEvent.click(screen.getByText('Remove Bookmark'));
@@ -60,7 +65,7 @@ it('removes a bookmark from a folder', async () => {
 });
 
 it('renames a folder', async () => {
-  renderComponent();
+  await renderComponent();
   await userEvent.click(screen.getByText('Create Folder'));
   await userEvent.click(screen.getByText('Rename Folder'));
   await waitFor(() => {
@@ -70,7 +75,7 @@ it('renames a folder', async () => {
 });
 
 it('deletes a folder', async () => {
-  renderComponent();
+  await renderComponent();
   await userEvent.click(screen.getByText('Create Folder'));
   await userEvent.click(screen.getByText('Delete Folder'));
   await waitFor(() => {
@@ -79,7 +84,7 @@ it('deletes a folder', async () => {
 });
 
 it('persists folder color', async () => {
-  renderComponent();
+  await renderComponent();
   await userEvent.click(screen.getByText('Create Folder'));
   await userEvent.click(screen.getByText('Set Color'));
   await waitFor(() => {
@@ -92,7 +97,7 @@ it('persists folder color', async () => {
 
 describe('pin operations', () => {
   it('pins a verse', async () => {
-    renderComponent();
+    await renderComponent();
     await userEvent.click(screen.getByText('Toggle Pin'));
     await waitFor(() => {
       expect(getPinned()).toHaveLength(1);
@@ -101,7 +106,7 @@ describe('pin operations', () => {
   });
 
   it('unpins a verse', async () => {
-    renderComponent();
+    await renderComponent();
     await userEvent.click(screen.getByText('Toggle Pin'));
     await userEvent.click(screen.getByText('Toggle Pin'));
     await waitFor(() => {
@@ -113,7 +118,7 @@ describe('pin operations', () => {
 
 describe('last read', () => {
   it('sets last read verse', async () => {
-    renderComponent();
+    await renderComponent();
     await userEvent.click(screen.getByText('Set Last Read'));
     await waitFor(() => {
       const last = getLastRead();

--- a/app/providers/__tests__/BookmarkContext/test-utils.tsx
+++ b/app/providers/__tests__/BookmarkContext/test-utils.tsx
@@ -5,7 +5,9 @@ import { BookmarkProvider, useBookmarks } from '@/app/providers/BookmarkContext'
 import { SettingsProvider } from '@/app/providers/SettingsContext';
 
 jest.mock('@/lib/api/chapters', () => ({
+  __esModule: true,
   getChapters: jest.fn().mockResolvedValue([]),
+  default: jest.fn().mockResolvedValue([]),
 }));
 
 jest.mock('@/lib/api', () => ({

--- a/app/shared/__tests__/ResponsiveVerseActions/ResponsiveVerseActions.interactions.test.tsx
+++ b/app/shared/__tests__/ResponsiveVerseActions/ResponsiveVerseActions.interactions.test.tsx
@@ -1,4 +1,4 @@
-import { screen, fireEvent } from '@testing-library/react';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
 
 import {
   renderResponsiveVerseActions,
@@ -6,58 +6,64 @@ import {
 } from '@/app/testUtils/responsiveVerseActionsTestUtils';
 
 describe('ResponsiveVerseActions interactions', () => {
-  it('should handle play button clicks', () => {
+  it('should handle play button clicks', async () => {
     const onPlayPause = jest.fn();
     renderResponsiveVerseActions({ onPlayPause });
 
-    const playButton = screen.getByRole('button', { name: /play/i });
+    const playButton = await screen.findByRole('button', { name: /play/i });
     fireEvent.click(playButton);
 
-    expect(onPlayPause).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(onPlayPause).toHaveBeenCalledTimes(1);
+    });
   });
 
-  it('should handle bookmark toggle', () => {
+  it('should handle bookmark toggle', async () => {
     const onBookmark = jest.fn();
     renderResponsiveVerseActions({ onBookmark });
 
-    const bookmarkButton = screen.getByRole('button', { name: /bookmark/i });
+    const bookmarkButton = await screen.findByRole('button', { name: /bookmark/i });
     fireEvent.click(bookmarkButton);
 
-    expect(onBookmark).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(onBookmark).toHaveBeenCalledTimes(1);
+    });
   });
 
-  it('should show correct play/pause state', () => {
+  it('should show correct play/pause state', async () => {
     const { rerender } = renderResponsiveVerseActions();
 
-    expect(screen.getByRole('button', { name: /play/i })).toBeInTheDocument();
+    await screen.findByRole('button', { name: /play/i });
 
     rerenderResponsiveVerseActions(rerender, { isPlaying: true });
 
-    expect(screen.getByRole('button', { name: /pause/i })).toBeInTheDocument();
+    await screen.findByRole('button', { name: /pause/i });
   });
 
-  it('should show loading state', () => {
+  it('should show loading state', async () => {
     renderResponsiveVerseActions({ isLoadingAudio: true });
 
-    expect(screen.getByRole('button', { name: /loading/i })).toBeInTheDocument();
+    await screen.findByRole('button', { name: /loading/i });
   });
 
-  it('should show bookmarked state', () => {
+  it('should show bookmarked state', async () => {
     renderResponsiveVerseActions({ isBookmarked: true });
 
-    expect(screen.getByRole('button', { name: /remove bookmark/i })).toBeInTheDocument();
+    await screen.findByRole('button', { name: /remove bookmark/i });
   });
 
-  it('should support keyboard navigation', () => {
+  it('should support keyboard navigation', async () => {
     renderResponsiveVerseActions();
 
-    const playButton = screen.getByRole('button', { name: /play/i });
-    screen.getByRole('button', { name: /bookmark/i });
+    const playButton = await screen.findByRole('button', { name: /play/i });
+    await screen.findByRole('button', { name: /bookmark/i });
 
     playButton.focus();
     expect(document.activeElement).toBe(playButton);
 
     fireEvent.keyDown(playButton, { key: 'Tab' });
-    expect(document.activeElement).not.toBe(playButton);
+    await waitFor(() => {
+      expect(document.activeElement).not.toBe(playButton);
+    });
   });
 });

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,6 +5,7 @@ import js from '@eslint/js';
 import noRelativeImportPaths from 'eslint-plugin-no-relative-import-paths';
 import unusedImports from 'eslint-plugin-unused-imports';
 import importPlugin from 'eslint-plugin-import';
+import testingLibrary from 'eslint-plugin-testing-library';
 import { noRawColorClasses } from './tools/scripts/eslint/no-raw-color-classes.mjs';
 import { noThemeConditionals } from './tools/scripts/eslint/no-theme-conditionals.mjs';
 import enforceArchitectureBoundaries from './tools/scripts/eslint/enforce-architecture-boundaries.mjs';
@@ -303,6 +304,9 @@ const eslintConfig = [
   // Test files can be longer and more permissive
   {
     files: ['**/__tests__/**', '**/*.test.ts', '**/*.test.tsx', '**/*.spec.ts'],
+    plugins: {
+      'testing-library': testingLibrary,
+    },
     rules: {
       '@typescript-eslint/no-explicit-any': 'off',
       'react/display-name': 'off',
@@ -315,6 +319,7 @@ const eslintConfig = [
           skipComments: true,
         },
       ],
+      'testing-library/await-async-utils': 'error',
     },
   },
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,6 +70,7 @@
         "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-no-relative-import-paths": "^1.6.1",
         "eslint-plugin-prettier": "^5.5.3",
+        "eslint-plugin-testing-library": "^6.2.2",
         "eslint-plugin-unused-imports": "^4.2.0",
         "http-server": "^14.1.1",
         "jest": "^30.0.5",
@@ -14814,6 +14815,165 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/eslint-plugin-testing-library": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-6.5.0.tgz",
+      "integrity": "sha512-Ls5TUfLm5/snocMAOlofSOJxNN0aKqwTlco7CrNtMjkTdQlkpSMaeTCDHCuXfzrI97xcx2rSCNeKeJjtpkNC1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/utils": "^5.62.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "eslint": "^7.5.0 || ^8.0.0 || ^9.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-testing-library/node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.62.0.tgz",
+      "integrity": "sha512-VXuvVvZeQCQb5Zgf4HAxc04q5j+WrNAtNh9OwCsCgpKqESMTu3tF/jhZ3xG6T4NZwWl65Bg8KuS2uEvhSfLl0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/visitor-keys": "5.62.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-testing-library/node_modules/@typescript-eslint/types": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.62.0.tgz",
+      "integrity": "sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-testing-library/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.62.0.tgz",
+      "integrity": "sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/visitor-keys": "5.62.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.7",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-testing-library/node_modules/@typescript-eslint/utils": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.62.0.tgz",
+      "integrity": "sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@types/json-schema": "^7.0.9",
+        "@types/semver": "^7.3.12",
+        "@typescript-eslint/scope-manager": "5.62.0",
+        "@typescript-eslint/types": "5.62.0",
+        "@typescript-eslint/typescript-estree": "5.62.0",
+        "eslint-scope": "^5.1.1",
+        "semver": "^7.3.7"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-testing-library/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.62.0.tgz",
+      "integrity": "sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "5.62.0",
+        "eslint-visitor-keys": "^3.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-testing-library/node_modules/eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-testing-library/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-plugin-testing-library/node_modules/estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/eslint-plugin-unused-imports": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-4.2.0.tgz",
@@ -26198,6 +26358,29 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/tsutils": {
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
+      "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^1.8.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      },
+      "peerDependencies": {
+        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
+      }
+    },
+    "node_modules/tsutils/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tty-browserify": {

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-no-relative-import-paths": "^1.6.1",
+    "eslint-plugin-testing-library": "^6.2.2",
     "eslint-plugin-prettier": "^5.5.3",
     "eslint-plugin-unused-imports": "^4.2.0",
     "http-server": "^14.1.1",


### PR DESCRIPTION
## Summary
- await BookmarkContext async state before assertions
- use async queries in ResponsiveVerseActions tests
- add eslint-plugin-testing-library with await-async-utils rule

## Testing
- `npm run lint` (fails: A `require()` style import is forbidden, `jest` is not defined)
- `npm test` (fails: Test Suites: 19 failed, 1 skipped, 132 passed, 151 of 152 total)

------
https://chatgpt.com/codex/tasks/task_b_68c66a052c08832fa771ccf699658d8b