### PR TITLE
refactor: extract audio prefetch helpers

### DIFF
--- a/app/shared/player/__tests__/useAudioPrefetch.test.ts
+++ b/app/shared/player/__tests__/useAudioPrefetch.test.ts
@@ -1,0 +1,157 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { useAudioPrefetch } from '@/app/shared/player/hooks/useAudioPrefetch';
+
+jest.mock('@/src/infrastructure/monitoring/Logger', () => ({
+  logger: {
+    debug: jest.fn(),
+    warn: jest.fn(),
+  },
+}));
+
+const AUDIO_URL = 'https://audio.example/test.mp3';
+
+const originalFetch = globalThis.fetch;
+const OriginalAbortController = globalThis.AbortController;
+const originalCreateObjectURL = URL.createObjectURL;
+const originalRevokeObjectURL = URL.revokeObjectURL;
+const createObjectUrlMock = jest.fn(() => 'object-url');
+const revokeObjectUrlMock = jest.fn();
+
+type PrefetchMocks = {
+  fetchMock: jest.Mock;
+  abortMock: jest.Mock;
+  createObjectUrlMock: jest.Mock;
+  revokeObjectUrlMock: jest.Mock;
+  blob: Blob;
+};
+
+function applyPrefetchMocks(): PrefetchMocks {
+  const abortMock = jest.fn();
+  class MockAbortController {
+    public readonly signal = {} as AbortSignal;
+    public abort = abortMock;
+  }
+  (globalThis as typeof globalThis & { AbortController: typeof AbortController }).AbortController =
+    MockAbortController as unknown as typeof AbortController;
+
+  const blob = new Blob(['audio-data'], { type: 'audio/mpeg' });
+  const fetchMock = jest.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    blob: jest.fn().mockResolvedValue(blob),
+  });
+  globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+  createObjectUrlMock.mockClear();
+  createObjectUrlMock.mockReturnValue('object-url');
+  revokeObjectUrlMock.mockClear();
+  (URL as unknown as { createObjectURL: typeof URL.createObjectURL }).createObjectURL =
+    createObjectUrlMock as unknown as typeof URL.createObjectURL;
+  (URL as unknown as { revokeObjectURL: typeof URL.revokeObjectURL }).revokeObjectURL =
+    revokeObjectUrlMock as unknown as typeof URL.revokeObjectURL;
+
+  return { fetchMock, abortMock, createObjectUrlMock, revokeObjectUrlMock, blob };
+}
+
+function restorePrefetchMocks(): void {
+  globalThis.fetch = originalFetch;
+  if (OriginalAbortController) {
+    globalThis.AbortController = OriginalAbortController;
+  } else {
+    delete (globalThis as typeof globalThis & { AbortController?: typeof AbortController })
+      .AbortController;
+  }
+}
+
+function runPrefetchMissTest(getMocks: () => PrefetchMocks): void {
+  it('prefetches and caches audio on cache miss', async () => {
+    const { result } = renderHook(() => useAudioPrefetch(null));
+
+    let objectUrl: string | null = null;
+    await act(async () => {
+      objectUrl = await result.current.prefetchAudio(AUDIO_URL);
+    });
+
+    const mocks = getMocks();
+    expect(mocks.fetchMock).toHaveBeenCalledWith(
+      AUDIO_URL,
+      expect.objectContaining({
+        headers: { Range: 'bytes=0-1024' },
+        signal: expect.any(Object),
+      })
+    );
+    expect(mocks.createObjectUrlMock).toHaveBeenCalledWith(mocks.blob);
+    expect(objectUrl).toBe('object-url');
+    expect(result.current.getPrefetchedUrl(AUDIO_URL)).toBe('object-url');
+    expect(mocks.abortMock).not.toHaveBeenCalled();
+  });
+}
+
+function runCacheHitTest(getMocks: () => PrefetchMocks): void {
+  it('returns cached audio without refetching on cache hit', async () => {
+    const { result } = renderHook(() => useAudioPrefetch(null));
+
+    await act(async () => {
+      await result.current.prefetchAudio(AUDIO_URL);
+    });
+
+    const mocks = getMocks();
+    mocks.fetchMock.mockClear();
+    mocks.createObjectUrlMock.mockClear();
+
+    let cachedUrl: string | null = null;
+    await act(async () => {
+      cachedUrl = await result.current.prefetchAudio(AUDIO_URL);
+    });
+
+    expect(mocks.fetchMock).not.toHaveBeenCalled();
+    expect(mocks.createObjectUrlMock).not.toHaveBeenCalled();
+    expect(cachedUrl).toBe('object-url');
+  });
+}
+
+function runCleanupTest(getMocks: () => PrefetchMocks): void {
+  it('cleans up cached audio on unmount', async () => {
+    const { result, unmount } = renderHook(() => useAudioPrefetch(null));
+
+    await act(async () => {
+      await result.current.prefetchAudio(AUDIO_URL);
+    });
+
+    unmount();
+    expect(getMocks().revokeObjectUrlMock).toHaveBeenCalledWith('object-url');
+  });
+}
+
+describe('useAudioPrefetch', () => {
+  let mocks: PrefetchMocks;
+
+  beforeEach(() => {
+    mocks = applyPrefetchMocks();
+  });
+
+  afterEach(() => {
+    restorePrefetchMocks();
+    jest.clearAllMocks();
+  });
+
+  const getMocks = (): PrefetchMocks => mocks;
+  runPrefetchMissTest(getMocks);
+  runCacheHitTest(getMocks);
+  runCleanupTest(getMocks);
+});
+
+afterAll(() => {
+  if (originalCreateObjectURL) {
+    URL.createObjectURL = originalCreateObjectURL;
+  } else {
+    delete (URL as { createObjectURL?: typeof URL.createObjectURL }).createObjectURL;
+  }
+
+  if (originalRevokeObjectURL) {
+    URL.revokeObjectURL = originalRevokeObjectURL;
+  } else {
+    delete (URL as { revokeObjectURL?: typeof URL.revokeObjectURL }).revokeObjectURL;
+  }
+});

--- a/app/shared/player/hooks/useAudioPrefetch.helpers.ts
+++ b/app/shared/player/hooks/useAudioPrefetch.helpers.ts
@@ -1,0 +1,128 @@
+import { MutableRefObject, useCallback, useEffect, useRef } from 'react';
+
+import { ILogger } from '@/src/domain/interfaces/ILogger';
+
+import { cleanupOldCache, clearCacheMap, getCacheStatsFromMap } from './useAudioPrefetch.cache';
+
+import type { PrefetchedAudio } from './useAudioPrefetch.types';
+
+export interface AudioPrefetchCacheHandlers {
+  prefetchAudio: (url: string) => Promise<string | null>;
+  getPrefetchedUrl: (url: string) => string | null;
+  clearCache: () => void;
+  getCacheStats: () => { count: number; totalSize: number };
+}
+
+interface UseAudioPrefetchCacheParams {
+  enabled: boolean;
+  maxCacheSize: number;
+  logger: ILogger;
+}
+
+interface PrefetchAudioTaskParams {
+  enabled: boolean;
+  maxCacheSize: number;
+  url: string;
+  cacheRef: MutableRefObject<Map<string, PrefetchedAudio>>;
+  prefetchingRef: MutableRefObject<Set<string>>;
+  loggerRef: MutableRefObject<ILogger>;
+}
+
+async function prefetchAudioTask({
+  enabled,
+  maxCacheSize,
+  url,
+  cacheRef,
+  prefetchingRef,
+  loggerRef,
+}: PrefetchAudioTaskParams): Promise<string | null> {
+  if (!enabled || !url || cacheRef.current.has(url) || prefetchingRef.current.has(url)) {
+    return cacheRef.current.get(url)?.objectUrl || null;
+  }
+
+  prefetchingRef.current.add(url);
+
+  try {
+    loggerRef.current.debug('Prefetching audio', { url });
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 30000);
+    const response = await fetch(url, {
+      signal: controller.signal,
+      headers: { Range: 'bytes=0-1024' },
+    });
+    clearTimeout(timeoutId);
+
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+
+    const blob = await response.blob();
+    const objectUrl = URL.createObjectURL(blob);
+
+    cacheRef.current.set(url, {
+      url,
+      blob,
+      objectUrl,
+      timestamp: Date.now(),
+      size: blob.size,
+    });
+
+    cleanupOldCache(cacheRef.current, maxCacheSize, loggerRef.current);
+
+    loggerRef.current.debug('Audio prefetched successfully', {
+      url,
+      size: blob.size,
+      cacheSize: cacheRef.current.size,
+    });
+
+    return objectUrl;
+  } catch (error) {
+    loggerRef.current.warn('Audio prefetch failed', {
+      url,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  } finally {
+    prefetchingRef.current.delete(url);
+  }
+}
+
+export function useAudioPrefetchCache({
+  enabled,
+  maxCacheSize,
+  logger,
+}: UseAudioPrefetchCacheParams): AudioPrefetchCacheHandlers {
+  const cacheRef = useRef<Map<string, PrefetchedAudio>>(new Map());
+  const prefetchingRef = useRef<Set<string>>(new Set());
+  const loggerRef = useRef<ILogger>(logger);
+
+  useEffect(() => {
+    loggerRef.current = logger;
+  }, [logger]);
+
+  const prefetchAudio = useCallback(
+    (url: string) =>
+      prefetchAudioTask({
+        enabled,
+        maxCacheSize,
+        url,
+        cacheRef,
+        prefetchingRef,
+        loggerRef,
+      }),
+    [enabled, maxCacheSize]
+  );
+
+  const getPrefetchedUrl = useCallback(
+    (url: string) => cacheRef.current.get(url)?.objectUrl || null,
+    []
+  );
+
+  const clearCache = useCallback(() => {
+    clearCacheMap(cacheRef.current, loggerRef.current);
+  }, []);
+
+  const getCacheStats = useCallback(() => getCacheStatsFromMap(cacheRef.current), []);
+
+  useEffect(() => () => clearCache(), [clearCache]);
+
+  return { prefetchAudio, getPrefetchedUrl, clearCache, getCacheStats };
+}

--- a/app/shared/player/hooks/useAudioPrefetch.ts
+++ b/app/shared/player/hooks/useAudioPrefetch.ts
@@ -1,12 +1,9 @@
-import { useEffect, useCallback, useRef } from 'react';
-
-import { ILogger } from '@/src/domain/interfaces/ILogger';
 import { logger } from '@/src/infrastructure/monitoring/Logger';
 
 import { useAdjacentAudioPrefetch } from './useAdjacentAudioPrefetch';
-import { cleanupOldCache, clearCacheMap, getCacheStatsFromMap } from './useAudioPrefetch.cache';
+import { useAudioPrefetchCache } from './useAudioPrefetch.helpers';
 
-import type { PrefetchOptions, PrefetchedAudio } from './useAudioPrefetch.types';
+import type { PrefetchOptions } from './useAudioPrefetch.types';
 
 export function useAudioPrefetch(
   currentAudioUrl: string | null,
@@ -26,64 +23,11 @@ export function useAudioPrefetch(
     enabled = true,
   } = options;
 
-  const cacheRef = useRef<Map<string, PrefetchedAudio>>(new Map());
-  const prefetchingRef = useRef<Set<string>>(new Set());
-  const loggerRef = useRef<ILogger>(logger);
-
-  const prefetchAudio = useCallback(
-    async (url: string): Promise<string | null> => {
-      if (!enabled || !url || cacheRef.current.has(url) || prefetchingRef.current.has(url)) {
-        return cacheRef.current.get(url)?.objectUrl || null;
-      }
-      prefetchingRef.current.add(url);
-      try {
-        loggerRef.current.debug('Prefetching audio', { url });
-        const controller = new AbortController();
-        const timeoutId = setTimeout(() => controller.abort(), 30000);
-        const response = await fetch(url, {
-          signal: controller.signal,
-          headers: { Range: 'bytes=0-1024' },
-        });
-        clearTimeout(timeoutId);
-        if (!response.ok) throw new Error(`HTTP ${response.status}`);
-        const blob = await response.blob();
-        const objectUrl = URL.createObjectURL(blob);
-        cacheRef.current.set(url, {
-          url,
-          blob,
-          objectUrl,
-          timestamp: Date.now(),
-          size: blob.size,
-        });
-        cleanupOldCache(cacheRef.current, maxCacheSize, loggerRef.current);
-        loggerRef.current.debug('Audio prefetched successfully', {
-          url,
-          size: blob.size,
-          cacheSize: cacheRef.current.size,
-        });
-        return objectUrl;
-      } catch (error) {
-        loggerRef.current.warn('Audio prefetch failed', {
-          url,
-          error: error instanceof Error ? error.message : String(error),
-        });
-        return null;
-      } finally {
-        prefetchingRef.current.delete(url);
-      }
-    },
-    [enabled, maxCacheSize]
-  );
-
-  const getPrefetchedUrl = useCallback((url: string): string | null => {
-    return cacheRef.current.get(url)?.objectUrl || null;
-  }, []);
-
-  const clearCache = useCallback(() => {
-    clearCacheMap(cacheRef.current, loggerRef.current);
-  }, []);
-
-  const getCacheStats = useCallback(() => getCacheStatsFromMap(cacheRef.current), []);
+  const { prefetchAudio, getPrefetchedUrl, clearCache, getCacheStats } = useAudioPrefetchCache({
+    enabled,
+    maxCacheSize,
+    logger,
+  });
 
   useAdjacentAudioPrefetch({
     enabled,
@@ -93,10 +37,8 @@ export function useAudioPrefetch(
     getNextAudioUrl,
     getPreviousAudioUrl,
     prefetchAudio,
-    logger: loggerRef.current,
+    logger,
   });
-
-  useEffect(() => () => clearCache(), [clearCache]);
 
   return { prefetchAudio, getPrefetchedUrl, clearCache, getCacheStats };
 }


### PR DESCRIPTION
## Summary
- extract the audio prefetch cache lifecycle into a dedicated helper so fetch orchestration, cache stats, and cleanup live outside the hook
- streamline `useAudioPrefetch` to coordinate the helper with adjacent-track prefetching while keeping the public API the same
- add focused unit tests that mock network and abort primitives to cover cache misses, hits, and cleanup behaviour

## Testing
- npm run lint *(fails: design token lint errors in `app/shared/components/responsive-image/ResponsiveImage.Extras.stories.tsx`)*
- npm run test -- useAudioPrefetch


------
https://chatgpt.com/codex/tasks/task_b_68ca691c3c3883219cd9514e71fc38e5