### PR TITLE
Refactor audio prefetch batching helper

### DIFF
--- a/app/shared/player/utils/__tests__/audioSegmentPrefetch.test.ts
+++ b/app/shared/player/utils/__tests__/audioSegmentPrefetch.test.ts
@@ -1,0 +1,115 @@
+import {
+  runAudioBatchPrefetch,
+  type AudioPrefetchItem,
+} from '@/app/shared/player/utils/audioSegmentPrefetch.helpers';
+
+describe('runAudioBatchPrefetch concurrency', () => {
+  it('respects the maxConcurrent limit when batching requests', async () => {
+    const items: AudioPrefetchItem[] = Array.from({ length: 5 }, (_, index) => ({
+      url: `https://example.com/audio-${index}.mp3`,
+      priority: index === 0 ? 'high' : 'medium',
+    }));
+
+    let active = 0;
+    let maxActive = 0;
+
+    const prefetchAudioStart = jest.fn(async () => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await Promise.resolve();
+      active -= 1;
+      return true;
+    });
+
+    await runAudioBatchPrefetch(items, prefetchAudioStart, {
+      maxConcurrent: 2,
+      delayBetween: 0,
+    });
+
+    expect(prefetchAudioStart).toHaveBeenCalledTimes(items.length);
+    expect(maxActive).toBe(2);
+  });
+});
+
+describe('runAudioBatchPrefetch delays', () => {
+  it('waits between batches based on the configured delay', async () => {
+    jest.useFakeTimers();
+
+    const items: AudioPrefetchItem[] = [
+      { url: 'https://example.com/high.mp3', priority: 'high' },
+      { url: 'https://example.com/medium.mp3', priority: 'medium' },
+    ];
+
+    const prefetchAudioStart = jest.fn(async () => true);
+
+    try {
+      const runPromise = runAudioBatchPrefetch(items, prefetchAudioStart, {
+        maxConcurrent: 1,
+        delayBetween: 200,
+      });
+
+      await Promise.resolve();
+      expect(prefetchAudioStart).toHaveBeenCalledTimes(1);
+
+      await jest.advanceTimersByTimeAsync(199);
+      await Promise.resolve();
+      expect(prefetchAudioStart).toHaveBeenCalledTimes(1);
+
+      await jest.advanceTimersByTimeAsync(1);
+      await runPromise;
+
+      expect(prefetchAudioStart).toHaveBeenCalledTimes(2);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});
+
+describe('runAudioBatchPrefetch results', () => {
+  it('returns aggregated results respecting priority ordering', async () => {
+    const items: AudioPrefetchItem[] = [
+      { url: 'https://example.com/low.mp3', priority: 'low' },
+      { url: 'https://example.com/high.mp3', priority: 'high' },
+      { url: 'https://example.com/medium.mp3' },
+    ];
+
+    let callCount = 0;
+    const nowSpy = jest.spyOn(performance, 'now').mockImplementation(() => {
+      callCount += 1;
+      return callCount * 5;
+    });
+
+    const prefetchAudioStart = jest
+      .fn(async (url: string) => url !== 'https://example.com/low.mp3')
+      .mockName('prefetchAudioStart');
+
+    try {
+      const results = await runAudioBatchPrefetch(items, prefetchAudioStart, {
+        maxConcurrent: 2,
+        delayBetween: 0,
+      });
+
+      expect(results).toEqual([
+        expect.objectContaining({
+          url: 'https://example.com/high.mp3',
+          success: true,
+          size: 0,
+        }),
+        expect.objectContaining({
+          url: 'https://example.com/medium.mp3',
+          success: true,
+          size: 0,
+        }),
+        expect.objectContaining({
+          url: 'https://example.com/low.mp3',
+          success: false,
+          size: 0,
+        }),
+      ]);
+
+      expect(results.every((result) => typeof result.duration === 'number')).toBe(true);
+    } finally {
+      nowSpy.mockRestore();
+    }
+  });
+});

--- a/app/shared/player/utils/audioSegmentPrefetch.ts
+++ b/app/shared/player/utils/audioSegmentPrefetch.ts
@@ -2,6 +2,7 @@ import { ILogger } from '@/src/domain/interfaces/ILogger';
 import { logger } from '@/src/infrastructure/monitoring/Logger';
 
 import { AudioSegmentCache } from './audioSegmentCache';
+import { getPriorityDistribution, runAudioBatchPrefetch } from './audioSegmentPrefetch.helpers';
 
 interface PrefetchResult {
   url: string;
@@ -100,15 +101,14 @@ export class AudioSegmentPrefetch {
     this.logger.info('Starting batch audio prefetch', {
       total: audioItems.length,
       maxConcurrent,
+      delayBetween,
       priorityDistribution: getPriorityDistribution(audioItems),
     });
-    const results = await prefetchAudioListHelper(
-      audioItems,
-      (url, opts) => this.prefetchAudioStart(url, opts),
-      this.logger,
-      { maxConcurrent, delayBetween }
-    );
-    return results;
+
+    return runAudioBatchPrefetch(audioItems, (url, opts) => this.prefetchAudioStart(url, opts), {
+      maxConcurrent,
+      delayBetween,
+    });
   }
 
   /**


### PR DESCRIPTION
## Summary
- extract a pure `runAudioBatchPrefetch` helper with typed inputs/outputs and priority distribution support
- update `AudioSegmentPrefetch.prefetchAudioList` to log metadata and delegate batching to the helper
- add unit coverage for concurrency limits, delay handling, and result aggregation of the batch helper

## Testing
- npm run lint *(fails: existing `token-rules/no-raw-color-classes` violations in unrelated Storybook files)*
- npm run test -- audioSegmentPrefetch

------
https://chatgpt.com/codex/tasks/task_b_68ca691dd1488321912732269b92fdae