### PR TITLE
test: refactor remote transport flushing tests

### DIFF
--- a/tests/unit/infrastructure/monitoring/RemoteTransport.flushing.test.ts
+++ b/tests/unit/infrastructure/monitoring/RemoteTransport.flushing.test.ts
@@ -6,62 +6,99 @@ import { RemoteTransport } from '@infra/monitoring';
 
 import { LogLevel, type LogEntry } from '@/src/infrastructure/monitoring/types';
 
-describe('RemoteTransport flushing', () => {
-  const createEntry = (level: LogLevel = LogLevel.INFO): LogEntry => ({
-    level,
-    message: 'msg',
-    timestamp: new Date(),
-  });
+type FetchWithTimeout = typeof import('@/lib/api/client').fetchWithTimeout;
 
-  let mockFetchWithTimeout: jest.MockedFunction<typeof import('@/lib/api/client').fetchWithTimeout>;
+const createEntry = (level: LogLevel = LogLevel.INFO): LogEntry => ({
+  level,
+  message: 'msg',
+  timestamp: new Date(),
+});
+
+const setupTransportMocks = () => {
+  let transport: RemoteTransport | undefined;
+  let mockFetchWithTimeout: jest.MockedFunction<FetchWithTimeout> | undefined;
 
   beforeEach(() => {
-    mockFetchWithTimeout = jest.fn();
-  });
-
-  afterEach(() => {
-    jest.restoreAllMocks();
-  });
-
-  it('flushes buffered logs to endpoint', async () => {
-    mockFetchWithTimeout.mockResolvedValue({ ok: true, status: 200 } as Response);
-
-    const transport = new RemoteTransport(
+    mockFetchWithTimeout = jest.fn() as jest.MockedFunction<FetchWithTimeout>;
+    transport = new RemoteTransport(
       'https://example.com',
       {},
       { fetchWithTimeout: mockFetchWithTimeout }
     );
+  });
+
+  afterEach(() => {
+    transport?.destroy();
+    jest.restoreAllMocks();
+  });
+
+  return () => {
+    if (!transport || !mockFetchWithTimeout) {
+      throw new Error('Transport mocks not initialized');
+    }
+
+    return { transport, mockFetchWithTimeout };
+  };
+};
+
+const expectSuccessfulFlush = (
+  mockFetchWithTimeout: jest.MockedFunction<FetchWithTimeout>,
+  { includeHeaders = false, entries = 1 }: { includeHeaders?: boolean; entries?: number } = {}
+) => {
+  expect(mockFetchWithTimeout).toHaveBeenCalled();
+
+  const [, requestInit] = mockFetchWithTimeout.mock.calls[0] ?? [];
+
+  if (!requestInit) {
+    throw new Error('Expected fetchWithTimeout to be called with a RequestInit payload');
+  }
+
+  expect(requestInit).toEqual(
+    expect.objectContaining({
+      method: 'POST',
+      body: expect.any(String),
+    })
+  );
+
+  if (includeHeaders) {
+    expect(requestInit.headers).toEqual(
+      expect.objectContaining({
+        'Content-Type': 'application/json',
+      })
+    );
+  }
+
+  if (entries !== undefined) {
+    const { body } = requestInit;
+
+    if (typeof body !== 'string') {
+      throw new Error('Expected fetchWithTimeout to be called with a string body');
+    }
+
+    const parsedBody = JSON.parse(body);
+    expect(parsedBody.entries).toHaveLength(entries);
+  }
+};
+
+describe('RemoteTransport flushing', () => {
+  const getContext = setupTransportMocks();
+
+  it('flushes buffered logs to endpoint', async () => {
+    const { transport, mockFetchWithTimeout } = getContext();
+    mockFetchWithTimeout.mockResolvedValue({ ok: true, status: 200 } as Response);
+
     const entry = createEntry();
     transport.log(entry);
 
     // Explicitly flush to trigger the fetch call
     await transport.flush();
 
-    expect(mockFetchWithTimeout).toHaveBeenCalled();
-    expect(mockFetchWithTimeout).toHaveBeenCalledWith(
-      'https://example.com',
-      expect.objectContaining({
-        method: 'POST',
-        headers: expect.objectContaining({
-          'Content-Type': 'application/json',
-        }),
-        body: expect.any(String),
-      })
-    );
-
-    const body = JSON.parse(mockFetchWithTimeout.mock.calls[0][1]?.body as string);
-    expect(body.entries).toHaveLength(1);
-    transport.destroy();
+    expectSuccessfulFlush(mockFetchWithTimeout, { includeHeaders: true, entries: 1 });
   });
 
   it('flushes immediately on error level', async () => {
+    const { transport, mockFetchWithTimeout } = getContext();
     mockFetchWithTimeout.mockResolvedValue({ ok: true, status: 200 } as Response);
-
-    const transport = new RemoteTransport(
-      'https://example.com',
-      {},
-      { fetchWithTimeout: mockFetchWithTimeout }
-    );
 
     // Log an error entry which should trigger immediate flush
     transport.log(createEntry(LogLevel.ERROR));
@@ -69,14 +106,6 @@ describe('RemoteTransport flushing', () => {
     // Wait a tick for the async flush to complete
     await new Promise((resolve) => process.nextTick(resolve));
 
-    expect(mockFetchWithTimeout).toHaveBeenCalled();
-    expect(mockFetchWithTimeout).toHaveBeenCalledWith(
-      'https://example.com',
-      expect.objectContaining({
-        method: 'POST',
-        body: expect.any(String),
-      })
-    );
-    transport.destroy();
+    expectSuccessfulFlush(mockFetchWithTimeout, { entries: 1 });
   });
 });


### PR DESCRIPTION
## Summary
- extract reusable helpers for the RemoteTransport flushing tests to simplify setup and assertions
- reuse the helpers in the existing specs to keep the scenarios focused on behavior

## Testing
- npm run test -- RemoteTransport.flushing.test.ts

------
https://chatgpt.com/codex/tasks/task_b_68ca6941e8a483218ffe3e8344936c2a