### PR TITLE
test: refactor offline e2e helpers

### DIFF
--- a/tests/e2e/utils/offline.ts
+++ b/tests/e2e/utils/offline.ts
@@ -1,0 +1,57 @@
+import { expect } from '@playwright/test';
+import type { BrowserContext, Page } from '@playwright/test';
+
+export async function cacheInitialContent(page: Page) {
+  await page.goto('/');
+  await page.waitForLoadState('networkidle');
+
+  const pathsToCache = ['/surah/1', '/juz/1'];
+
+  for (const path of pathsToCache) {
+    await page.goto(path);
+    await page.waitForLoadState('networkidle');
+  }
+
+  await page.goto('/');
+  await page.waitForLoadState('networkidle');
+}
+
+export type OfflineNavigationResult = {
+  linkCount: number;
+  destinationTitle: string | null;
+};
+
+export async function attemptOfflineNavigation(
+  page: Page,
+  context: BrowserContext
+): Promise<OfflineNavigationResult> {
+  await page.goto('/');
+  await page.waitForLoadState('networkidle');
+
+  await context.setOffline(true);
+
+  const navLinks = page.locator('nav a, [role="navigation"] a');
+  const linkCount = await navLinks.count();
+  let destinationTitle: string | null = null;
+
+  if (linkCount > 0) {
+    await navLinks.first().click();
+    await page.waitForTimeout(1000);
+    destinationTitle = await page.title();
+  }
+
+  return { linkCount, destinationTitle };
+}
+
+export async function expectAppShellStructure(page: Page) {
+  await expect(page.locator('html')).toHaveAttribute('lang', 'en');
+
+  const viewport = await page.viewportSize();
+  expect(viewport).toBeTruthy();
+
+  const bodyStyle = await page.locator('body').evaluate((el) => {
+    return window.getComputedStyle(el).backgroundColor;
+  });
+
+  expect(bodyStyle).not.toBe('rgba(0, 0, 0, 0)');
+}


### PR DESCRIPTION
## Summary
- add shared offline helper utilities for caching, navigation, and shell assertions
- restructure the offline functionality e2e spec into smaller suites that reuse the helpers

## Testing
- npx playwright test tests/e2e/offline-functionality.spec.ts *(fails: Next.js build cannot find module 'ajv/dist/compile/codegen')*

------
https://chatgpt.com/codex/tasks/task_b_68ca6941ea588321b32967f831ba949f