### PR TITLE
refactor: delegate audio prefetch helpers

### DIFF
--- a/app/shared/player/utils/__tests__/audioSegmentPrefetch.test.ts
+++ b/app/shared/player/utils/__tests__/audioSegmentPrefetch.test.ts
@@ -1,9 +1,44 @@
 import {
-  runAudioBatchPrefetch,
+  prefetchAudioBatch,
   type AudioPrefetchItem,
+  type AudioPrefetchResult,
 } from '@/app/shared/player/utils/audioSegmentPrefetch.helpers';
 
-describe('runAudioBatchPrefetch concurrency', () => {
+import type { ILogger } from '@/src/domain/interfaces/ILogger';
+
+const createLogger = (): Pick<ILogger, 'info'> => ({
+  info: jest.fn<void, Parameters<ILogger['info']>>(),
+});
+
+const buildResultItems = (): AudioPrefetchItem[] => [
+  { url: 'https://example.com/low.mp3', priority: 'low' },
+  { url: 'https://example.com/high.mp3', priority: 'high' },
+  { url: 'https://example.com/medium.mp3' },
+];
+
+const expectSampleResults = (results: AudioPrefetchResult[]): void => {
+  expect(results).toEqual([
+    expect.objectContaining({
+      url: 'https://example.com/high.mp3',
+      success: true,
+      size: 0,
+    }),
+    expect.objectContaining({
+      url: 'https://example.com/medium.mp3',
+      success: true,
+      size: 0,
+    }),
+    expect.objectContaining({
+      url: 'https://example.com/low.mp3',
+      success: false,
+      size: 0,
+    }),
+  ]);
+
+  expect(results.every((result) => typeof result.duration === 'number')).toBe(true);
+};
+
+describe('prefetchAudioBatch concurrency', () => {
   it('respects the maxConcurrent limit when batching requests', async () => {
     const items: AudioPrefetchItem[] = Array.from({ length: 5 }, (_, index) => ({
       url: `https://example.com/audio-${index}.mp3`,
@@ -21,9 +56,13 @@ describe('runAudioBatchPrefetch concurrency', () => {
       return true;
     });
 
-    await runAudioBatchPrefetch(items, prefetchAudioStart, {
-      maxConcurrent: 2,
-      delayBetween: 0,
+    const logger = createLogger();
+
+    await prefetchAudioBatch({
+      items,
+      options: { maxConcurrent: 2, delayBetween: 0 },
+      logger,
+      prefetchAudioStart,
     });
 
     expect(prefetchAudioStart).toHaveBeenCalledTimes(items.length);
@@ -31,7 +70,7 @@ describe('runAudioBatchPrefetch concurrency', () => {
   });
 });
 
-describe('runAudioBatchPrefetch delays', () => {
+describe('prefetchAudioBatch delays', () => {
   it('waits between batches based on the configured delay', async () => {
     jest.useFakeTimers();
 
@@ -41,11 +80,14 @@ describe('runAudioBatchPrefetch delays', () => {
     ];
 
     const prefetchAudioStart = jest.fn(async () => true);
+    const logger = createLogger();
 
     try {
-      const runPromise = runAudioBatchPrefetch(items, prefetchAudioStart, {
-        maxConcurrent: 1,
-        delayBetween: 200,
+      const runPromise = prefetchAudioBatch({
+        items,
+        options: { maxConcurrent: 1, delayBetween: 200 },
+        logger,
+        prefetchAudioStart,
       });
 
       await Promise.resolve();
@@ -65,14 +107,53 @@ describe('runAudioBatchPrefetch delays', () => {
   });
 });
 
-describe('runAudioBatchPrefetch results', () => {
-  it('returns aggregated results respecting priority ordering', async () => {
+describe('prefetchAudioBatch logging', () => {
+  it('logs normalized options and priority distribution before execution', async () => {
     const items: AudioPrefetchItem[] = [
-      { url: 'https://example.com/low.mp3', priority: 'low' },
       { url: 'https://example.com/high.mp3', priority: 'high' },
-      { url: 'https://example.com/medium.mp3' },
+      { url: 'https://example.com/low.mp3', priority: 'low' },
     ];
 
+    const logger = createLogger();
+    const prefetchAudioStart = jest.fn(async () => true);
+
+    await prefetchAudioBatch({
+      items,
+      options: { maxConcurrent: 0, delayBetween: -50 },
+      logger,
+      prefetchAudioStart,
+    });
+
+    expect(logger.info).toHaveBeenCalledWith('Starting batch audio prefetch', {
+      total: items.length,
+      maxConcurrent: 1,
+      delayBetween: 0,
+      priorityDistribution: { high: 1, low: 1 },
+    });
+  });
+});
+
+describe('prefetchAudioBatch results', () => {
+  it('invokes prefetchAudioStart respecting priority order', async () => {
+    const logger = createLogger();
+    const prefetchAudioStart = jest.fn(async () => true);
+
+    await prefetchAudioBatch({
+      items: buildResultItems(),
+      options: { maxConcurrent: 2, delayBetween: 0 },
+      logger,
+      prefetchAudioStart,
+    });
+
+    expect(prefetchAudioStart.mock.calls.map(([callUrl]) => callUrl)).toEqual([
+      'https://example.com/high.mp3',
+      'https://example.com/medium.mp3',
+      'https://example.com/low.mp3',
+    ]);
+  });
+
+  it('returns aggregated results with duration metrics', async () => {
+    const logger = createLogger();
     let callCount = 0;
     const nowSpy = jest.spyOn(performance, 'now').mockImplementation(() => {
       callCount += 1;
@@ -84,30 +165,14 @@ describe('runAudioBatchPrefetch results', () => {
       .mockName('prefetchAudioStart');
 
     try {
-      const results = await runAudioBatchPrefetch(items, prefetchAudioStart, {
-        maxConcurrent: 2,
-        delayBetween: 0,
+      const results = await prefetchAudioBatch({
+        items: buildResultItems(),
+        options: { maxConcurrent: 2, delayBetween: 0 },
+        logger,
+        prefetchAudioStart,
       });
 
-      expect(results).toEqual([
-        expect.objectContaining({
-          url: 'https://example.com/high.mp3',
-          success: true,
-          size: 0,
-        }),
-        expect.objectContaining({
-          url: 'https://example.com/medium.mp3',
-          success: true,
-          size: 0,
-        }),
-        expect.objectContaining({
-          url: 'https://example.com/low.mp3',
-          success: false,
-          size: 0,
-        }),
-      ]);
-
-      expect(results.every((result) => typeof result.duration === 'number')).toBe(true);
+      expectSampleResults(results);
     } finally {
       nowSpy.mockRestore();
     }

--- a/app/shared/player/utils/audioSegmentPrefetch.helpers.ts
+++ b/app/shared/player/utils/audioSegmentPrefetch.helpers.ts
@@ -1,3 +1,5 @@
+import type { ILogger } from '@/src/domain/interfaces/ILogger';
+
 export type AudioPrefetchPriority = 'high' | 'medium' | 'low';
 
 export interface AudioPrefetchItem {
@@ -17,6 +19,19 @@ export interface RunAudioBatchPrefetchOptions {
   delayBetween?: number;
 }
 
+export type NormalizedRunAudioBatchPrefetchOptions = Required<RunAudioBatchPrefetchOptions>;
+
+const DEFAULT_BATCH_OPTIONS: NormalizedRunAudioBatchPrefetchOptions = Object.freeze({
+  maxConcurrent: 3,
+  delayBetween: 100,
+});
+
+const PRIORITY_ORDER: Record<AudioPrefetchPriority, number> = {
+  high: 0,
+  medium: 1,
+  low: 2,
+};
+
 export function getPriorityDistribution(items: AudioPrefetchItem[]): Record<string, number> {
   return items.reduce<Record<string, number>>((acc, item) => {
     const priority = item.priority || 'medium';
@@ -25,24 +40,73 @@ export function getPriorityDistribution(items: AudioPrefetchItem[]): Record<stri
   }, {});
 }
 
+export function normalizeRunAudioBatchPrefetchOptions(
+  options: RunAudioBatchPrefetchOptions = {}
+): NormalizedRunAudioBatchPrefetchOptions {
+  const {
+    maxConcurrent = DEFAULT_BATCH_OPTIONS.maxConcurrent,
+    delayBetween = DEFAULT_BATCH_OPTIONS.delayBetween,
+  } = options;
+
+  return {
+    maxConcurrent: Math.max(1, Math.floor(maxConcurrent)),
+    delayBetween: Math.max(0, delayBetween),
+  } satisfies NormalizedRunAudioBatchPrefetchOptions;
+}
+
+export function sortAudioPrefetchItemsByPriority(items: AudioPrefetchItem[]): AudioPrefetchItem[] {
+  return [...items].sort(
+    (a, b) => PRIORITY_ORDER[a.priority || 'medium'] - PRIORITY_ORDER[b.priority || 'medium']
+  );
+}
+
+export function createAudioPrefetchBatches(
+  items: AudioPrefetchItem[],
+  maxConcurrent: number
+): AudioPrefetchItem[][] {
+  if (items.length === 0) {
+    return [];
+  }
+
+  const batches: AudioPrefetchItem[][] = [];
+  for (let index = 0; index < items.length; index += maxConcurrent) {
+    batches.push(items.slice(index, index + maxConcurrent));
+  }
+
+  return batches;
+}
+
+export function waitForNextAudioBatch(delay: number): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(resolve, delay);
+  });
+}
+
+export function logAudioBatchPrefetchStart(
+  logger: Pick<ILogger, 'info'>,
+  items: AudioPrefetchItem[],
+  options: NormalizedRunAudioBatchPrefetchOptions
+): void {
+  logger.info('Starting batch audio prefetch', {
+    total: items.length,
+    maxConcurrent: options.maxConcurrent,
+    delayBetween: options.delayBetween,
+    priorityDistribution: getPriorityDistribution(items),
+  });
+}
+
 export async function runAudioBatchPrefetch(
   items: AudioPrefetchItem[],
   prefetchAudioStart: (url: string, opts: { priority?: AudioPrefetchPriority }) => Promise<boolean>,
   options: RunAudioBatchPrefetchOptions = {}
 ): Promise<AudioPrefetchResult[]> {
-  const { maxConcurrent = 3, delayBetween = 100 } = options;
-  const safeMaxConcurrent = Math.max(1, Math.floor(maxConcurrent));
-  const safeDelayBetween = Math.max(0, delayBetween);
-
-  const priorityOrder: Record<AudioPrefetchPriority, number> = { high: 0, medium: 1, low: 2 };
-  const sortedItems = [...items].sort(
-    (a, b) => priorityOrder[a.priority || 'medium'] - priorityOrder[b.priority || 'medium']
-  );
-
+  const normalizedOptions = normalizeRunAudioBatchPrefetchOptions(options);
+  const sortedItems = sortAudioPrefetchItemsByPriority(items);
+  const batches = createAudioPrefetchBatches(sortedItems, normalizedOptions.maxConcurrent);
   const results: AudioPrefetchResult[] = [];
 
-  for (let i = 0; i < sortedItems.length; i += safeMaxConcurrent) {
-    const batch = sortedItems.slice(i, i + safeMaxConcurrent);
+  for (let index = 0; index < batches.length; index += 1) {
+    const batch = batches[index];
     const batchResults = await Promise.all(
       batch.map(async (item) => {
         const startTime = performance.now();
@@ -60,11 +124,28 @@ export async function runAudioBatchPrefetch(
 
     results.push(...batchResults);
 
-    const hasMoreItems = i + safeMaxConcurrent < sortedItems.length;
-    if (hasMoreItems && safeDelayBetween > 0) {
-      await new Promise((resolve) => setTimeout(resolve, safeDelayBetween));
+    const hasMoreItems = index < batches.length - 1;
+    if (hasMoreItems && normalizedOptions.delayBetween > 0) {
+      await waitForNextAudioBatch(normalizedOptions.delayBetween);
     }
   }
 
   return results;
+}
+
+export async function prefetchAudioBatch({
+  items,
+  options,
+  logger,
+  prefetchAudioStart,
+}: {
+  items: AudioPrefetchItem[];
+  options?: RunAudioBatchPrefetchOptions;
+  logger: Pick<ILogger, 'info'>;
+  prefetchAudioStart: (url: string, opts: { priority?: AudioPrefetchPriority }) => Promise<boolean>;
+}): Promise<AudioPrefetchResult[]> {
+  const normalizedOptions = normalizeRunAudioBatchPrefetchOptions(options);
+  logAudioBatchPrefetchStart(logger, items, normalizedOptions);
+
+  return runAudioBatchPrefetch(items, prefetchAudioStart, normalizedOptions);
 }


### PR DESCRIPTION
## Summary
- move audio batching, sorting, and logging into reusable helpers and expose a `prefetchAudioBatch` orchestrator
- update `AudioSegmentPrefetch.prefetchAudioList` to validate inputs and delegate to the helper-focused workflow
- extend the audio prefetch test suite to cover concurrency, delay handling, logging, and result ordering using mocked fetches

## Testing
- npm run lint
- npm run test -- audioSegmentPrefetch

------
https://chatgpt.com/codex/tasks/task_b_68ca7654fab08321b4727553bd5e4d69